### PR TITLE
Collision Course update

### DIFF
--- a/Aeternus_Continuum.cat
+++ b/Aeternus_Continuum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b8c1-c778-0dfe-7f91" name="Aeternus Continuum" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b8c1-c778-0dfe-7f91" name="Aeternus Continuum" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="26e1-4a06-0aab-8bff" name="Scourge" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -18,23 +18,33 @@
             <characteristic name="CST" typeId="c638-3794-83aa-d72a">2</characteristic>
           </characteristics>
         </profile>
-        <profile id="d8fb-0859-3195-15ed" name="Wrecking Claw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-          <characteristics>
-            <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-            <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
-            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-            <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Stun Module (Spike)</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink id="57b9-8d2f-2ddd-f983" name="Servo Booster (Charge)" hidden="false" targetId="c2dc-35ac-058b-1d8f" type="rule"/>
-        <infoLink id="8fee-877a-a19d-c6aa" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f8eb-0201-129b-eed5" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="09a5-9d4a-1569-9d5a" name="Wrecking Claw" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="1783-8081-c7bb-987e" name="Wrecking Claw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="51fb-a424-1933-ab46" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
+            <infoLink id="16b3-275e-b8a5-5370" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="4a73-98b1-5bfe-c38c" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="900c-3b29-e5e5-a88d" name="Cortex" hidden="false" collective="false" import="true">
           <constraints>
@@ -209,14 +219,43 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="bbb4-9929-a2e9-fb7d" name="Nailer" hidden="false" targetId="4450-76f1-d9b6-7f5d" type="profile"/>
         <infoLink id="035f-20fb-0cd5-daed" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
-        <infoLink id="f219-fcc4-3ba1-d069" name="Phase Sequencer (Spike)" hidden="false" targetId="094d-bc41-04ce-a04e" type="rule"/>
-        <infoLink id="7e12-363a-bec6-0ca3" name="Fusion Saw" hidden="false" targetId="3be9-7629-0a25-65bd" type="profile"/>
+        <infoLink id="f219-fcc4-3ba1-d069" name="Phase Sequencer (Spike)" hidden="false" targetId="6d0a-6652-e0d3-5715" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dbc4-9cc8-c5d9-b304" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e875-beb8-b000-e65b" name="Fusion Saw" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20f7-ccd6-9c67-3027" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35e-3c03-630f-46d8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b558-e7bf-1795-14cd" name="Fusion Saw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="06bd-7d7d-7109-dcda" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="707a-442b-5ef2-2bbe" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ab34-09d3-a36d-353c" name="Nailer" hidden="false" collective="false" import="true" targetId="83bc-8013-087c-f0fc" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6532-c7a7-8b9a-3d5b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea82-ba12-4aa8-afd2" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -243,12 +282,34 @@
         <infoLink id="3e0e-2d0a-0eaf-4997" name="Arcantrik Amplifier (Charge)" hidden="false" targetId="a4ab-9b99-4e38-42f9" type="rule"/>
         <infoLink id="94e1-362a-a92c-1c80" name="Arc Relay (13)" hidden="false" targetId="270b-a680-a6ce-5c59" type="rule"/>
         <infoLink id="dea4-1143-5d82-9399" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
-        <infoLink id="45f5-f684-fd8f-198d" name="Pychokinetic Hood" hidden="false" targetId="5a7d-a103-228e-9c9c" type="profile"/>
-        <infoLink id="e848-5d0e-ca95-bc7d" name="Spray Weapon" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3cf1-1688-65bb-6876" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8bbf-6c9e-288d-6203" name="Psychokinetic Hood" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea56-43a3-3ab3-329e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa1-16a0-e502-3adb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b4b1-2f80-52ba-7a0b" name="Pychokinetic Hood" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="7fd9-c8a5-6882-dfe2" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="2f41-2833-b40b-0d11" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+            <infoLink id="f24b-4eda-4767-e08c" name="Spray" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -271,17 +332,63 @@
           </characteristics>
         </profile>
       </profiles>
+      <rules>
+        <rule id="7278-6290-be46-07ef" name="Impulse Reactor (Charge)" hidden="false">
+          <description>While charged, if this unit has an activation token on it at the start of your turn, you can remove the activation token from this model.</description>
+        </rule>
+      </rules>
       <infoLinks>
-        <infoLink id="8250-04c7-564c-bad9" name="Impulse Reactor (Charge)" hidden="false" targetId="6be3-b8b0-01b9-900c" type="rule"/>
         <infoLink id="9c33-e324-d9d7-f2da" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
-        <infoLink id="7a9d-c709-628b-801e" name="Mangler" hidden="false" targetId="a7bc-b77f-ead6-5f0d" type="profile"/>
-        <infoLink id="51a2-0638-44d4-1030" name="Shredder" hidden="false" targetId="d13f-2c55-788a-d7c4" type="profile"/>
-        <infoLink id="0e34-7bf9-2d8b-4114" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
-        <infoLink id="c724-6b82-b66f-ee04" name="Power Attack (Spike)" hidden="false" targetId="f45d-f7bc-3379-d648" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e1e2-a3d5-3f80-76b5" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0174-1e36-a901-7041" name="Shredder" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a92a-cc4c-98dc-4a73" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b254-d3c1-8294-3567" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8755-0ca4-df45-0600" name="Shredder" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="aef1-5461-d46c-7d5b" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="acf7-b668-cd9c-6130" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="937b-29a8-5375-f4e4" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1999-7596-b2b2-3797" name="Mangler" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b06e-5fde-71df-7c39" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5062-96ee-9287-7134" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e97b-601a-3f3d-666d" name="Mangler" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="9662-d82b-058c-b874" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="ed23-ac95-a992-0e12" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+            <infoLink id="c43a-0474-a274-8716" name="Power Attack (Spike)" hidden="false" targetId="f45d-f7bc-3379-d648" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -320,9 +427,11 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="f84d-766c-e85e-bcb9" name="Battle Cruiser" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="f3ef-9737-27e0-5d4c" name="Battle Cruiser" hidden="false" targetId="af72-afc1-816d-8398" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="2506-e583-05cb-daa3" name="Battle Cruiser" hidden="false">
+                  <description>When this model makes a ranged attack, immediately after the attack is resolved, this model can move up to 1&quot;.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -331,6 +440,24 @@
               <infoLinks>
                 <infoLink id="9d6c-6375-5a3b-adc1" name="Impulse Reciprocator (Spike)" hidden="false" targetId="45b4-f347-8366-5808" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fa28-d38f-e8da-b929" name="Ghost" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="8f9a-1e83-0d91-670d" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e955-b0af-db46-bf39" name="Oracle" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="bdec-e290-67aa-65c7" name="Oracle Targeting Array (Spike)" hidden="false">
+                  <description>Once per activation, this model can spike to use Oracle Targeting Array. Thatactivation, this model ignores cover and Stealth.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -357,9 +484,24 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="151f-10f1-d8db-497c" name="Displacer" hidden="false" collective="false" import="true" targetId="6d70-0229-9f2f-d0a3" type="selectionEntry">
+                <entryLink id="0f20-6a4c-3889-1db9" name="Displacer" hidden="false" collective="false" import="true" targetId="810d-7f5e-0cc9-357c" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="eaec-8557-fb5e-c5b0" name="Fusion Saw" hidden="false" collective="false" import="true" targetId="9720-8160-a95c-bd92" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cb34-621e-b80c-6871" name="Hellstormer" hidden="false" collective="false" import="true" targetId="900b-6e21-78f3-5daf" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9b78-1b25-eada-e15a" name="Stinger Cannon" hidden="false" collective="false" import="true" targetId="e96c-18d1-9b2d-ff9b" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -384,50 +526,87 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="f8b7-459a-b73e-40c6" name="Right Arm" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="139a-57c7-4b4c-4450" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="c2c0-5812-4622-c735" name="Void Splitter" hidden="false" collective="false" import="true" targetId="5626-a2a6-90ca-dfa2" type="selectionEntry">
-                  <costs>
-                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="c3ff-bd38-5b1f-ad5d" name="Fusion Scythe" hidden="false" collective="false" import="true" targetId="6fbc-31a0-2a81-593b" type="selectionEntry">
-                  <costs>
-                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="52a1-8163-0159-beb3" name="Displacer" hidden="false" collective="false" import="true" targetId="6d70-0229-9f2f-d0a3" type="selectionEntry">
-                  <costs>
-                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="fe00-9f3b-4219-9ee8" name="Right Shoulder" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d225-a45b-a5f5-57e1" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="b262-2232-7bf0-d0f4" name="Hollowphage Cannon" hidden="false" collective="false" import="true" targetId="3ab1-efd4-333b-fcc4" type="selectionEntry">
+                <entryLink id="0365-048f-607a-022e" name="Entrophier" hidden="false" collective="false" import="true" targetId="84c7-2af8-1f36-4793" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="09d3-a535-e31f-d717" name="Rocket Pod" hidden="false" collective="false" import="true" targetId="23ff-0aa3-29ff-4328" type="selectionEntry">
+                <entryLink id="d204-f989-de28-132d" name="Hex Cannon" hidden="false" collective="false" import="true" targetId="db59-7f9f-a962-b3b9" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="afd3-2ea0-9755-ca53" name="Starfall Cannon" hidden="false" collective="false" import="true" targetId="432a-d11f-6174-8b62" type="selectionEntry">
+                <entryLink id="b4e8-ec05-8ac9-a338" name="Obliterator" hidden="false" collective="false" import="true" targetId="5074-7610-eb0b-605f" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c69d-3ac2-a17a-e119" name="Right Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9af-f5a1-96a5-1586" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9d5f-b5a6-fecf-db4e" name="Void Splitter" hidden="false" collective="false" import="true" targetId="5626-a2a6-90ca-dfa2" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f93a-a581-4e0c-7fb2" name="Fusion Scythe" hidden="false" collective="false" import="true" targetId="6fbc-31a0-2a81-593b" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6eb4-8fa8-e742-f0fc" name="Displacer" hidden="false" collective="false" import="true" targetId="810d-7f5e-0cc9-357c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1f9c-46d2-3cf2-efed" name="Fusion Saw" hidden="false" collective="false" import="true" targetId="9720-8160-a95c-bd92" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="81d8-39ba-530c-9d5d" name="Hellstormer" hidden="false" collective="false" import="true" targetId="900b-6e21-78f3-5daf" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8bae-1197-2e95-0738" name="Stinger Cannon" hidden="false" collective="false" import="true" targetId="e96c-18d1-9b2d-ff9b" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="37b1-b72c-b9b2-d03f" name="Right Shoulder" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1f5-4758-087a-af96" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5996-9fbf-79d5-6ee0" name="Hollowphage Cannon" hidden="false" collective="false" import="true" targetId="3ab1-efd4-333b-fcc4" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="5c4f-88db-41eb-d642" name="Rocket Pod" hidden="false" collective="false" import="true" targetId="23ff-0aa3-29ff-4328" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="df1a-558d-8ee8-7255" name="Starfall Cannon" hidden="false" collective="false" import="true" targetId="432a-d11f-6174-8b62" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="aa5f-072a-0f16-5a1a" name="Entrophier" hidden="false" collective="false" import="true" targetId="84c7-2af8-1f36-4793" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8443-3203-f4b3-6190" name="Hex Cannon" hidden="false" collective="false" import="true" targetId="db59-7f9f-a962-b3b9" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4d6d-a0cd-7e1c-ac74" name="Obliterator" hidden="false" collective="false" import="true" targetId="5074-7610-eb0b-605f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -437,7 +616,7 @@
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9922-4d6f-825a-c326" name="Grafter" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9922-4d6f-825a-c326" name="Grafter" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe18-324f-debf-ab01" type="max"/>
       </constraints>
@@ -455,15 +634,43 @@
           </characteristics>
         </profile>
       </profiles>
+      <rules>
+        <rule id="505e-04fa-69d3-fccd" name="Adrenalizer (Charge)" hidden="false">
+          <description>When this model is charged, other warrior models within 5&quot; of it gain +1 ARM and do not suffer continuous effects.</description>
+        </rule>
+        <rule id="0ff5-8b19-c998-7188" name="Resurrection Protocol (Spike)" hidden="false">
+          <description>During its activation and while within 10&quot; of a target friendly squad, this model can spike to return up to two destroyed trooper models to the squad. Place these models within 2&quot; of another model in the squad. A squad can never have more than three trooper models as a result of Resurrection Protocol.</description>
+        </rule>
+      </rules>
       <infoLinks>
-        <infoLink id="c4ef-288e-d4f2-1fc0" name="Bone Saw" hidden="false" targetId="5479-2583-7063-5ebf" type="profile"/>
-        <infoLink id="aae3-b146-e45d-d002" name="Adrenalizer (Charge)" hidden="false" targetId="44eb-53c1-d618-01b8" type="rule"/>
         <infoLink id="dcaf-b3ea-8080-00eb" name="Repair (Action)" hidden="false" targetId="4339-3e50-7d6c-5e50" type="rule"/>
-        <infoLink id="d592-9d46-ea63-8d05" name="Resurrection Protocol (Spike)" hidden="false" targetId="343c-4bc9-0f7d-c741" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0965-649d-0825-13e5" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="891c-7ffc-56a8-bebe" name="Bone Saw" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc73-5865-ff79-d58d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02a-145f-7fe8-5e54" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6362-b1d1-90e7-cfd3" name="Bone Saw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d8fe-2bf0-aec5-a1ba" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="8e16-bb47-01f1-66ac" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -487,13 +694,19 @@
       </profiles>
       <infoLinks>
         <infoLink id="cfa3-ae94-d961-43a1" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
-        <infoLink id="76fb-e9cd-e762-0c9a" name="Phase Sequencer (Spike)" hidden="false" targetId="094d-bc41-04ce-a04e" type="rule"/>
-        <infoLink id="cb64-05f2-f7a3-1a72" name="Hex Cannon" hidden="false" targetId="5c6d-04d2-2b21-ab2c" type="profile"/>
-        <infoLink id="c37b-4936-8e32-fd6a" name="Malefactor" hidden="false" targetId="cbff-67cf-93ba-4651" type="rule"/>
+        <infoLink id="76fb-e9cd-e762-0c9a" name="Phase Sequencer (Spike)" hidden="false" targetId="6d0a-6652-e0d3-5715" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b1e1-c675-70d5-7235" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="58f7-9c45-1e26-1b04" name="Hex Cannon" hidden="false" collective="false" import="true" targetId="db59-7f9f-a962-b3b9" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d289-ae07-6649-2e2f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a95e-053a-bc79-edb8" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -516,18 +729,370 @@
           </characteristics>
         </profile>
       </profiles>
+      <rules>
+        <rule id="4a98-0a5e-e6ea-16b6" name="Thanotech Reclaimer (Spike)" hidden="false">
+          <description>This model can spike to use Thanotech at any time during its activation. When it does so you can return any Cypher card in your discard pile to your hand.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="e53c-7589-1ebf-2af4" name="Arc Relay (13)" hidden="false" targetId="270b-a680-a6ce-5c59" type="rule"/>
         <infoLink id="b8fe-1c24-62e9-97f1" name="Kinetic Field (Charge)" hidden="false" targetId="66bd-9300-b5cb-3769" type="rule"/>
         <infoLink id="cc31-d7d1-28f1-8486" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
         <infoLink id="6952-e49f-4d2f-c7e6" name="Psycho Relay" hidden="false" targetId="4769-9fbb-0de5-9570" type="rule"/>
-        <infoLink id="9fc4-be03-f6a0-1d64" name="Thanotech Reclaimer (Spike)" hidden="false" targetId="c3f2-8bf3-13f4-a729" type="rule"/>
-        <infoLink id="d182-b0f5-ece3-eb16" name="Spray Weapon" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
-        <infoLink id="a2e6-1343-2fb2-2f79" name="Soul Grinder" hidden="false" targetId="0231-a14f-4ed4-f5e7" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9023-d371-af6a-fec7" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="42ac-e910-a062-eb58" name="Soul Grinder" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="186f-2dfd-9334-1426" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9306-3239-141f-73ef" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d02b-12f1-4be4-c17c" name="Soul Grinder" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="c23e-1831-db1f-0110" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+            <infoLink id="be11-0c8a-9b23-6627" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="9097-bafa-7ec2-b701" name="Spray" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b75-e976-662b-8346" name="Vassal Raiders" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b8-1965-bb37-8d27" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="82d8-8fd0-0b7e-a5c0" name="Vassal Raiders" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">6</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">2</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="89c9-78b8-3007-5e81" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
+        <infoLink id="b89e-329b-733f-0cf2" name="Phase Sequencer (Spike)" hidden="false" targetId="6d0a-6652-e0d3-5715" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="525b-fae6-f25a-baf6" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1f00-3d42-0d37-efb7" name="Spiker" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a00a-ff7f-f3a7-635a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e4-264f-374b-5608" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5248-4105-a33e-45ab" name="Spiker" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="49c9-a723-a49f-89cb" name="Carrion Ablator (Spike)" hidden="false">
+              <description>Immediately after hitting a model with this weapon, this model can spike once to cause the model hit to suffer the corrosion continuous effect.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="253a-7b25-fbcf-fb98" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="8137-9e87-9e6f-3bc8" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="c1a4-cb5f-d965-3ef7" name="Fusion Blade" hidden="false" collective="false" import="true" targetId="ddfc-dacc-8d2e-265f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6b4-c850-2027-104a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="996b-350b-9891-f7c1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6593-8fcc-496a-35fd" name="Raker" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="increment" field="ff9b-aedf-2795-fbf9" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b75-e976-662b-8346" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a2d-0a10-6d23-5c90" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0097-5d27-e84b-28c8" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9b-aedf-2795-fbf9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4003-0864-336f-4551" name="Raker" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">*</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">4</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">2</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">4</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">4</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">1</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">+1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e064-0425-4124-311e" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
+        <infoLink id="b7ae-b6cd-a1aa-c81c" name="Phase Stalker (Spike)" hidden="false" targetId="b6f8-55ca-8c6e-f088" type="rule"/>
+        <infoLink id="71ba-d9e8-bfd0-86f9" name="Spotlight (Charge)" hidden="false" targetId="7f04-3809-34a7-682d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e4ef-96ae-16ac-3cb4" name="New CategoryLink" hidden="false" targetId="fa79-7113-8f14-037f" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5f9b-35e9-3187-e7f0" name="Mandibles" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d872-c5e2-0f62-dae0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="943f-1092-c620-e272" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="735d-b1f8-ef23-7777" name="Mandibles" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e96c-c814-d972-b394" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="be73-47bf-e8d9-782e" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+            <infoLink id="eee7-fa58-f3e3-ac90" name="Lock Down" hidden="false" targetId="c5f2-b7a9-63fd-e500" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e99c-cb35-52ce-3e5d" name="Defense Pylon" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dde-6ff6-6800-8e2f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b5b5-e76b-4d11-a404" name="Defense Pylon" hidden="false" typeId="f21f-e3fc-861e-7041" typeName="Mantlet">
+          <characteristics>
+            <characteristic name="SPD" typeId="9a1a-1996-43a0-5ebf">-</characteristic>
+            <characteristic name="MAT" typeId="ef7d-7e69-bb45-465a">-</characteristic>
+            <characteristic name="RAT" typeId="0dee-6f34-8704-e237">-</characteristic>
+            <characteristic name="DEF" typeId="7629-6783-48fa-04fb">1</characteristic>
+            <characteristic name="ARM" typeId="8838-aacd-9ec7-99b1">4</characteristic>
+            <characteristic name="DMG" typeId="c150-c260-a91e-5bdb">2</characteristic>
+            <characteristic name="CST" typeId="e127-231f-27ff-e6a4">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="746c-8b5b-c3ee-c84c" name="Arcane Parasite" hidden="false">
+          <description>If an enemy Cypher targets a model within 3&quot; of this model, after the Cypher is resolved, you can charge a friendly model within 3&quot; of this model.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="bac8-1bee-c699-8468" name="Deployable Cover" hidden="false" targetId="7d92-ecde-abcd-cac0" type="rule"/>
+        <infoLink id="e24e-6e37-4fd1-c0fe" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="f6ad-4b62-0dda-878d" name="Blast Shielding" hidden="false" targetId="4a41-827f-6868-3087" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a055-dc3c-3d28-c100" name="New CategoryLink" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b02-d02a-a93e-a744" name="Scythe" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="5e38-163c-23bf-8530" name="Scythe" hidden="false" typeId="8503-75a8-8ab2-161b" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="SPD" typeId="d513-8b95-8e8b-9643">8</characteristic>
+            <characteristic name="MAT" typeId="dd71-a3b1-b5d2-4126">4</characteristic>
+            <characteristic name="RAT" typeId="4972-6b8a-4cc9-a39d">3</characteristic>
+            <characteristic name="DEF" typeId="5d4e-e604-9d25-f35d">3</characteristic>
+            <characteristic name="ARM" typeId="5dd6-51ae-08e3-2c18">4</characteristic>
+            <characteristic name="DMG" typeId="804d-3ef2-0e46-d938">4</characteristic>
+            <characteristic name="CST" typeId="c28f-24c8-5446-8b51">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="cc05-d389-8e78-f783" name="Meneuvers" hidden="false">
+          <infoLinks>
+            <infoLink id="0d33-e444-8a18-e095" name="Force the Engine" hidden="false" targetId="9354-9e39-e744-08a6" type="rule"/>
+            <infoLink id="fc16-a3fa-9506-761d" name="Low Flying" hidden="false" targetId="ce6e-6659-02dc-eca9" type="rule"/>
+            <infoLink id="a832-44a4-0ed0-2e02" name="Wing Roll" hidden="false" targetId="5e9a-1de7-6d6b-9741" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="fd95-2f4e-1f2b-6619" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="a027-134e-8ba1-f5be" name="Phase Stalker (Spike)" hidden="false" targetId="b6f8-55ca-8c6e-f088" type="rule"/>
+        <infoLink id="ef49-05b3-5b61-caab" name="Scything Run (Charge)" hidden="false" targetId="fc0a-7c28-eae5-bf6f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4a96-2db1-4b9e-7f14" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6f87-841e-6a09-4144" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee31-512f-543b-3ebb" type="max"/>
+            <constraint field="ecbb-d452-36d4-0214" scope="3b02-d02a-a93e-a744" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8d0-f441-cc0e-67fe" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="861b-086c-1298-5f8b" name="Heavy Displacer" hidden="false" collective="false" import="true" targetId="e39d-5e87-4c8e-fb67" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="602b-c9d9-7554-4593" name="Heavy Stinger" hidden="false" collective="false" import="true" targetId="d121-0337-412b-f044" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="881e-94b8-7627-1fe0" name="Hollowphage Cannon" hidden="false" collective="false" import="true" targetId="3ab1-efd4-333b-fcc4" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9615-c30a-54c8-9a1e" name="Heavy Fusion Blade" hidden="false" collective="false" import="true" targetId="b8ac-4c9b-dd2b-ae83" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3471-fc5b-0ff0-01eb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3d3-74f0-b542-1df3" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a697-8e12-5ad9-b6da" name="Aenigma" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="23ac-674c-f812-70ba" name="Aenigma" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">8</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">4</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">4</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">4</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">4</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="4964-bafc-23d7-dc00" name="Meneuvers" hidden="false">
+          <rules>
+            <rule id="9298-2310-6ad9-2183" name="Meditations of Annihilation" hidden="false">
+              <description>If this model is not charged, you can immediately charge it with 1 Arc.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="c57a-e627-02d0-eea4" name="Force the Engine" hidden="false" targetId="9354-9e39-e744-08a6" type="rule"/>
+            <infoLink id="89ae-bf17-51ba-3573" name="Low Flying" hidden="false" targetId="ce6e-6659-02dc-eca9" type="rule"/>
+            <infoLink id="e2e4-3010-d5af-f9af" name="Wing Roll" hidden="false" targetId="5e9a-1de7-6d6b-9741" type="rule"/>
+            <infoLink id="4ead-2277-320d-3eac" name="Evasive Action" hidden="false" targetId="9b9d-84ff-3a95-2643" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="800c-53e6-dc5a-5156" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="46d1-b312-acbd-b474" name="Phase Stalker (Spike)" hidden="false" targetId="b6f8-55ca-8c6e-f088" type="rule"/>
+        <infoLink id="981f-d424-a284-6aee" name="Scything Run (Charge)" hidden="false" targetId="fc0a-7c28-eae5-bf6f" type="rule"/>
+        <infoLink id="c40f-ce22-9751-50e8" name="Arc Relay (10)" hidden="false" targetId="d687-ce36-bcf1-95c6" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="592b-f277-610e-7dc2" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+        <categoryLink id="f3d8-68cd-1297-3a8a" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8f58-5f13-8654-44cd" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250a-09a6-9433-4b06" type="max"/>
+            <constraint field="ecbb-d452-36d4-0214" scope="a697-8e12-5ad9-b6da" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fcf-636e-2a27-9566" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="82b0-792b-ad15-2162" name="Hellfire Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="17d1-f018-1811-8d83" name="Hellfire Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                    <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="d893-e96d-e835-9afc" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                <infoLink id="2385-ddb0-e3d5-90d3" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+                <infoLink id="0c68-7555-bac1-c70d" name="Spray" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+                <infoLink id="d9c5-b762-2dfd-14cb" name="Arcantrik Amplifier (Charge)" hidden="false" targetId="a4ab-9b99-4e38-42f9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="e9dc-e5db-b326-a290" name="Heavy Displacer" hidden="false" collective="false" import="true" targetId="e39d-5e87-4c8e-fb67" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4b4b-f3cf-076b-ffbd" name="Heavy Stinger" hidden="false" collective="false" import="true" targetId="d121-0337-412b-f044" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cf95-c029-a8f1-2110" name="Hollowphage Cannon" hidden="false" collective="false" import="true" targetId="3ab1-efd4-333b-fcc4" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="95fa-e0bb-c5b8-562f" name="Heavy Fusion Blade" hidden="false" collective="false" import="true" targetId="b8ac-4c9b-dd2b-ae83" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeac-08a6-cfc6-acd9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c36f-36b0-4dfa-f17d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -540,91 +1105,169 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="3ab1-efd4-333b-fcc4" name="Hollowphage Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e7fe-3309-adca-6d59" name="Hollowphage Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="b9d0-fc60-6556-eaea" name="Corrosion" hidden="false" targetId="5555-7c59-a346-7406" type="rule"/>
-        <infoLink id="c8d5-788a-9a34-3262" name="Hollowphage Cannon" hidden="false" targetId="ee7a-cf49-d993-70c6" type="profile"/>
+        <infoLink id="a97d-218e-0762-b309" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83bc-8013-087c-f0fc" name="Nailer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4d3d-bafe-8ce4-bdf9" name="Nailer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="e04a-87b9-22f0-5d78" name="Nailer" hidden="false" targetId="4450-76f1-d9b6-7f5d" type="profile"/>
+        <infoLink id="ac0d-8b32-14dc-307a" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="e938-f8ad-0ac3-6107" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="23ff-0aa3-29ff-4328" name="Rocket Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="06f9-d161-929a-368e" name="Rocket Pod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="f1ee-7125-a1a5-f862" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="d3ca-0940-e698-8239" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="4a1e-0fdb-9871-57e2" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
       <infoLinks>
-        <infoLink id="d587-96b1-444e-fcfa" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
-        <infoLink id="3c06-cbcc-77e9-b1b7" name="Rocket Pod" hidden="false" targetId="04c0-8859-3e27-5957" type="profile"/>
+        <infoLink id="d587-96b1-444e-fcfa" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="49b5-591f-4ee9-38b6" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96e8-780b-cab0-fd95" name="Force Rod" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8cf7-34b2-f3b0-0f85" name="Force Rod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="3b96-0cc1-aedf-e529" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
-        <infoLink id="0277-3d68-5235-2c78" name="Force Rod" hidden="false" targetId="6155-e651-efec-801e" type="profile"/>
+        <infoLink id="8d07-6154-bf05-4512" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="2c39-b502-6841-259e" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5626-a2a6-90ca-dfa2" name="Void Splitter" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="76c6-9c98-ecd1-986e" name="Void Splitter" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="c43f-8d08-1d59-4a01" name="Shockwave (Spike)" hidden="false" targetId="33bc-8e3b-8cea-c61e" type="rule"/>
-        <infoLink id="f883-7c01-b7c4-9276" name="Void Splitter" hidden="false" targetId="0072-f66c-1d6d-1f64" type="profile"/>
+        <infoLink id="0c68-dcbe-8371-3cae" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="3145-bd99-82d4-5c90" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6fbc-31a0-2a81-593b" name="Fusion Scythe" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b674-1f00-e1b8-bb02" name="Fusion Scythe" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="f01a-3477-edda-0ebb" name="Fusion Scythe" hidden="false" targetId="0806-6a6c-5d96-4afb" type="profile"/>
+        <infoLink id="5553-4252-de96-04ad" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="de11-058a-73a2-d412" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6d70-0229-9f2f-d0a3" name="Displacer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="ddf0-98f8-56ce-2958" name="Displacer" hidden="false" targetId="54eb-02d8-c177-b45b" type="profile"/>
-        <infoLink id="3a40-2b1b-8483-d2ae" name="Dislocator (Spike)" hidden="false" targetId="ebb5-c4d8-2797-e523" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="432a-d11f-6174-8b62" name="Starfall Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="46b5-7ba0-f97a-983d" name="Starfall Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
         <infoLink id="a894-4e50-2625-bd58" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
-        <infoLink id="6b59-a95d-bf79-4991" name="Starfall Cannon" hidden="false" targetId="13e5-e69b-1021-0831" type="profile"/>
+        <infoLink id="a5e8-6f2c-cbb7-74b6" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="b83b-4b29-69aa-b4cc" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ac9e-e938-ad6f-5c8f" name="Reaper" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2bc8-6efa-40d3-a067" name="Reaper" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="cc13-5f75-58b6-7c3c" name="Reaper" hidden="false" targetId="926f-4536-02cf-de03" type="profile"/>
         <infoLink id="0b7a-380b-87e2-1008" name="Winch" hidden="false" targetId="92ca-26e8-fd63-05ce" type="rule"/>
+        <infoLink id="b153-f491-3cc7-7293" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="6824-af12-e296-a670" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e96c-18d1-9b2d-ff9b" name="Stinger Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="22c3-7d21-a579-74b3" name="Stinger Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="1c97-1028-46ff-765d" name="Stinger Cannon" hidden="false" targetId="0be5-7dfc-852d-773b" type="profile"/>
         <infoLink id="6de8-5119-a314-80a8" name="Targeter (Charge)" hidden="false" targetId="1891-8584-c483-7085" type="rule"/>
+        <infoLink id="4de3-938c-7f4c-e86f" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="868d-3637-ad24-225a" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d47-ccf2-f881-a571" name="Cloaking Device" hidden="false" collective="false" import="true" type="upgrade">
@@ -632,191 +1275,188 @@
         <infoLink id="102c-d291-5c64-4132" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="84c7-2af8-1f36-4793" name="Entrophier" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="dc09-871e-051d-a2f3" name="Entrophier" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="bd3a-8d40-c1de-a612" name="Entrophier" hidden="false" targetId="1ea4-d190-49f3-a9f5" type="profile"/>
         <infoLink id="9812-b038-3f3a-b380" name="Lock Down" hidden="false" targetId="c5f2-b7a9-63fd-e500" type="rule"/>
         <infoLink id="a6b0-e177-f60d-2461" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
+        <infoLink id="5168-6dcc-1f28-00f4" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="aa5a-8897-622c-02d2" name="Cold" hidden="false" targetId="6c6d-1869-f1f7-4c03" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="db59-7f9f-a962-b3b9" name="Hex Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1a93-739c-1849-7880" name="Hex Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="f7f2-5324-d7b4-b84f" name="Hex Cannon" hidden="false" targetId="5c6d-04d2-2b21-ab2c" type="profile"/>
         <infoLink id="77b0-cd9c-e8d2-f114" name="Malefactor" hidden="false" targetId="cbff-67cf-93ba-4651" type="rule"/>
+        <infoLink id="92b4-1d04-bba4-da08" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="6379-0065-bdfb-44b0" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="810d-7f5e-0cc9-357c" name="Displacer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1b7a-f9dd-68f7-3ae5" name="Displacer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">13</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fe7c-208a-5c99-131c" name="Dislocator (Spike)" hidden="false" targetId="ebb5-c4d8-2797-e523" type="rule"/>
+        <infoLink id="e27c-c4a9-5a42-2a8c" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="b30a-20a2-378a-497d" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9720-8160-a95c-bd92" name="Fusion Saw" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2794-4502-714c-9246" name="Fusion Saw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bd65-19a8-072b-eb1f" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="a005-7413-bfd0-bf81" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="3b2a-408c-5327-f0d1" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="900b-6e21-78f3-5daf" name="Hellstormer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7368-e52b-2ddb-8d94" name="Hellstormer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1e27-e7b6-44cf-d492" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="18e7-d53d-7511-a9ad" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="e047-d22a-0d94-7d22" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5074-7610-eb0b-605f" name="Obliterator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a0e8-1f0a-ba1a-c96b" name="Obliterator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5e8a-3a35-db4e-471d" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="f624-029f-553d-884c" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="cdc9-ccd8-9795-7e96" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8ac-4c9b-dd2b-ae83" name="Heavy Fusion Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9148-65e3-96aa-0cba" name="Heavy Fusion Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="046c-2352-58f0-2a01" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="29b1-7a22-cf0c-591d" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e39d-5e87-4c8e-fb67" name="Heavy Displacer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4d00-1aca-7038-3cca" name="Heavy Displacer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">15</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0772-961c-674f-2fbf" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="adb4-3343-8fad-764e" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="e7d3-37ee-74d3-d8df" name="Dislocator (Spike)" hidden="false" targetId="ebb5-c4d8-2797-e523" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d121-0337-412b-f044" name="Heavy Stinger" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="066f-59e6-aa32-37da" name="Heavy Stinger" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="81e6-7443-c8a4-8874" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="e7e8-bd65-d55b-a4c1" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="4f2b-9c2b-e10b-d262" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="1ee6-567f-0511-226a" name="Targeter (Charge)" hidden="false" targetId="1891-8584-c483-7085" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
-  <sharedProfiles>
-    <profile id="4450-76f1-d9b6-7f5d" name="Nailer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="5a7d-a103-228e-9c9c" name="Pychokinetic Hood" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Spray Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a7bc-b77f-ead6-5f0d" name="Claw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Power Attack (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d13f-2c55-788a-d7c4" name="Shredder" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Strafe</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3be9-7629-0a25-65bd" name="Fusion Saw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="ee7a-cf49-d993-70c6" name="Hollowphage Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Corrosion</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Corrosion</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6155-e651-efec-801e" name="Force Rod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Repulsor</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="04c0-8859-3e27-5957" name="Rocket Pod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic and Explosion</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Blast Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="0072-f66c-1d6d-1f64" name="Void Splitter" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Shockwave (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="13e5-e69b-1021-0831" name="Starfall Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">High Intensity (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="54eb-02d8-c177-b45b" name="Displacer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">13</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Dislocator (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5479-2583-7063-5ebf" name="Bone Saw" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="0806-6a6c-5d96-4afb" name="Fusion Scythe" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="5c6d-04d2-2b21-ab2c" name="Hex Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Malefactor</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="0231-a14f-4ed4-f5e7" name="Soul Grinder" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Spray Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="926f-4536-02cf-de03" name="Reaper" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Winch</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="0be5-7dfc-852d-773b" name="Stinger Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Targeter (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1ea4-d190-49f3-a9f5" name="Entrophier" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Cold</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Lock Down, Stun Module (Spike)</characteristic>
-      </characteristics>
-    </profile>
-  </sharedProfiles>
+  <sharedRules>
+    <rule id="6d0a-6652-e0d3-5715" name="Phase Sequencer (Spike)" hidden="false">
+      <description>Once per activation, this unit can spike to use Phase Sequencer. That activation, models in this squad can move through obstructions and through other models if they have enough movement to move completely past them.</description>
+    </rule>
+    <rule id="fc0a-7c28-eae5-bf6f" name="Scything Run (Charge)" hidden="false">
+      <description>After advancing during it&apos;s activation while charged, this model can make one melee attack against each enemy model it moved over while activating.</description>
+    </rule>
+    <rule id="9354-9e39-e744-08a6" name="Force the Engine" hidden="false">
+      <description>This model gains +4 SPD this activation, but suffers 1 damage point.</description>
+    </rule>
+    <rule id="ce6e-6659-02dc-eca9" name="Low Flying" hidden="false">
+      <description>This model loses Flight and Sycthing Run, but adds one POWER die to attack rolls against models without Flight. This Maneuver expires at the end of this activation.</description>
+    </rule>
+    <rule id="5e9a-1de7-6d6b-9741" name="Wing Roll" hidden="false">
+      <description>When this model is missed by an attack, after the attack is resolved, this model can immediately make an attack targeting the model that missed it. This Maneuver expires at the start of this unit&apos;s next activation or immediately after this model makes an attack as the result of Wing Roll.</description>
+    </rule>
+  </sharedRules>
 </catalogue>

--- a/Empyreans.cat
+++ b/Empyreans.cat
@@ -1,0 +1,1502 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="0bdd-ac10-4d4d-42c3" name="Empyreans" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="3b83-edca-a89f-61b4" name="Saber Strike Force" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="466c-038b-f867-3477" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c4e7-9d27-d7f3-934f" name="Saber Strike Force" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">6</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">3</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c256-5b61-5098-7701" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="194d-7da6-6276-f971" name="Eclipse Drive (Spike)" hidden="false" targetId="2ae4-f32f-f0eb-cc1f" type="rule"/>
+        <infoLink id="04d5-afc7-18c0-17ae" name="Havoc Engine (Charge)" hidden="false" targetId="9d24-af6a-5a5f-296b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="87c1-204e-fccc-f097" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c40c-cc1d-180f-4341" name="Ion Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b65b-5d5a-a956-1900" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfdf-c822-8172-cfa2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f12a-57cb-1dec-5738" name="Ion Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="745a-1ec6-f8eb-9afd" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+            <infoLink id="731d-fb2f-8991-4dc0" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+            <infoLink id="88cc-87e4-f31d-cd76" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="b9ff-1185-a1a2-7201" name="Fusion Blade" hidden="false" collective="false" import="true" targetId="ddfc-dacc-8d2e-265f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0c-66bd-d43c-7634" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db51-3017-564d-d28a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a467-6b0e-782b-16a7" name="Tentacle Strike" hidden="false" collective="false" import="true" targetId="b90c-c2c1-f3ab-abca" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb44-dc2e-9786-dc96" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cbd-74ae-a0f7-926c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c28-d46a-1c8e-a5a4" name="Saber Guardians" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5610-588f-248d-ad8d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6f6e-a902-3b78-e4a3" name="Saber Guardians" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">4</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">3</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2c1d-d5dc-e24d-ab0d" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="841f-601a-1983-7262" name="Eclipse Drive (Spike)" hidden="false" targetId="2ae4-f32f-f0eb-cc1f" type="rule"/>
+        <infoLink id="5f12-31bd-90cc-4f52" name="Havoc Engine (Charge)" hidden="false" targetId="9d24-af6a-5a5f-296b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6f7e-c0b8-4995-877f" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c6e1-f32a-125f-45f0" name="Reticulum" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2de3-e086-f47a-5a16" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c29-9689-29a9-8ad8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c125-94a0-3726-3045" name="Reticulum" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="bf4d-57c6-51da-dd5d" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="607a-b14c-b070-de1c" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+            <infoLink id="d4e4-ea39-0d7f-1170" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="efe2-f29b-fc73-4eda" name="Tentacle Strike" hidden="false" collective="false" import="true" targetId="b90c-c2c1-f3ab-abca" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="902a-8259-b9bd-5f73" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30c6-4891-a78c-e78c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a163-82a8-37fb-7452" name="Saber Vanguard" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e0d-62e7-c46d-bb24" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="430c-3c44-8421-6ec9" name="Saber Vanguard" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">6</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">3</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b483-40a7-13bf-e177" name="Sidestep" hidden="false">
+          <description>Whent his model hits an enemy model with an attack, after the attack is resolved, this model can move up to 1&quot;.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3d5e-455f-38f7-6ea3" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="0481-e2fc-6755-8fdb" name="Eclipse Drive (Spike)" hidden="false" targetId="2ae4-f32f-f0eb-cc1f" type="rule"/>
+        <infoLink id="8ce1-7f56-43a2-45d6" name="Havoc Engine (Charge)" hidden="false" targetId="9d24-af6a-5a5f-296b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e707-d7c6-e279-49a3" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+        <categoryLink id="33d9-b314-59de-c60b" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bdd8-b3d4-0c47-7375" name="Fusion Scythe" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3341-d9d0-8ed0-f532" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="187f-d646-44ce-4eb9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dae3-64d9-f579-1d2b" name="Fusion Scythe" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="94ec-5d1f-06f0-18f7" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="4254-c0d0-c57e-5067" name="Tentacle Strike" hidden="false" collective="false" import="true" targetId="b90c-c2c1-f3ab-abca" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb1a-9a43-50d3-f5ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3cd-4751-2b74-26b1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f57d-065b-65ea-651e" name="Aerolith" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="f078-379c-3759-7aad" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b83-edca-a89f-61b4" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c28-d46a-1c8e-a5a4" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a163-82a8-37fb-7452" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f078-379c-3759-7aad" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c095-f9fb-98b3-d83f" name="Aerolith" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">*</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">4</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">4</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">1</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="c638-e96b-301c-1608" name="Attachment" hidden="false">
+          <description>This model can be attached to Saber squads.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6b43-eb04-1136-4fd2" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
+        <infoLink id="0361-7993-8061-a60e" name="Intercept Driver (Spike)" hidden="false" targetId="ec44-3a92-93db-2564" type="rule"/>
+        <infoLink id="9c71-a32b-8984-ee85" name="Spotlight (Charge)" hidden="false" targetId="7f04-3809-34a7-682d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fda6-e9b1-e480-7cf4" name="New CategoryLink" hidden="false" targetId="fa79-7113-8f14-037f" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a077-1f99-f96a-e544" name="Pulse Array" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5c1-7854-390e-676b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1257-c1d9-ed8e-bdb4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3a4d-f250-d31f-6450" name="Pulse Array" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoGroups>
+            <infoGroup id="28ed-4918-2c51-dded" name="Energy Type" hidden="false">
+              <infoLinks>
+                <infoLink id="bea1-bb61-0e84-8c3d" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+                <infoLink id="4c4e-8d03-5817-41f8" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+              </infoLinks>
+            </infoGroup>
+          </infoGroups>
+          <infoLinks>
+            <infoLink id="d71f-4469-d73b-6504" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+            <infoLink id="cdf2-af56-5c6a-d207" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d9d9-e753-9bd0-985a" name="Oculus" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="998e-6014-42e1-6639" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bc00-b6f9-f8ef-a7bd" name="Oculus" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">3</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">3</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">3</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">4</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">2</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f99c-eae5-dd3b-fe95" name="Arc Capacitor" hidden="false">
+          <description>When you channel a Fury Cypher through this model, after the attack is resolved, you can charge this model with up to 1 Arc if it is not already charged.</description>
+        </rule>
+        <rule id="42a0-4f58-697f-f6d6" name="Phase Aligner (Charge)" hidden="false">
+          <description>While this model is charged, ignore line of sight when resolving Fury attacks channeled through it.</description>
+        </rule>
+        <rule id="3c8a-8e07-f583-647d" name="Psycho Reactor (Spike)" hidden="false">
+          <description>When a Fury attack is channeled through this model, it can spike to reroll the attack or damage roll.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f41c-89c4-3cb8-1b9d" name="Arc Relay (14)" hidden="false" targetId="4e47-8e74-5d7d-c90f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c54f-477a-5e2d-8222" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="61d9-e116-f293-bc9f" name="Consecrator" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ca0-68a4-ca07-9f29" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c949-6801-f43a-bb78" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4a03-0f5c-e868-2422" name="Consecrator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="b6e5-c8ab-2040-7380" name="Null Strike" hidden="false" targetId="f174-cd6d-3802-1cbc" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4ff9-10e4-d111-044e" name="Factotum" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afc1-dadc-a84d-4598" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bd86-71d7-fcb8-b3b0" name="Factotum" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">4</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">3</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">3</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a286-e24e-20db-2cdb" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="aa40-8d8f-9b3e-4392" name="Jump Start (Spike)" hidden="false" targetId="058b-f612-39f3-2bd6" type="rule"/>
+        <infoLink id="e75a-36cd-3b49-df28" name="Repair (Action)" hidden="false" targetId="4339-3e50-7d6c-5e50" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fd1a-5295-16c3-022c" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0fb2-60a8-d53b-4b19" name="Tentacle Clamps" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee6e-be8a-db8a-cac2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596b-65ff-cac2-b9a0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e6f9-18e8-2493-396f" name="Tentacle Clamps" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="717a-8c54-ffff-46f2" name="Cortex Shock (Charge)" hidden="false">
+              <description>A model hit by this weapon while this model is charged suffers the system failure continuous effect.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="b1a7-bef9-19a1-856f" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="7c54-736f-35fe-37cd" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b43f-fd77-2b67-71ea" name="Fulcrum" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45fc-d377-af11-1690" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8b9d-2ff4-0f2d-07b5" name="Fulcrum" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">3</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">4</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">2</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b6a1-5fe5-c2c4-8cc1" name="Void Phaser (Spike)" hidden="false">
+          <description>During it&apos;s activation, this model can spike to reposition a target friendly unit within 5&quot; of it. You can immediately reposition the target unit anywhere within 3&quot; of it&apos;s current location.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1664-1ead-60f9-d2be" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="3b84-acd4-fb57-73c3" name="Slip Field (Charge)" hidden="false" targetId="77c5-00b4-a116-e328" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dce5-54d1-000b-d59d" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9e9d-1cab-a231-0730" name="Void Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e906-2aba-1df2-197d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4b-14f5-24d3-f21c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d70a-9eef-3e98-aea8" name="Void Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="5730-d26b-1ec2-77b2" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+            <infoLink id="f5d3-1616-be7f-5ad4" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="6459-82e4-3a95-2988" name="Dislocator (Spike)" hidden="false" targetId="ebb5-c4d8-2797-e523" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4596-ecbb-2137-d7b1" name="Carapax" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff3a-489c-ad72-fb21" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8302-f827-dfcc-9118" name="Carapax" hidden="false" typeId="f21f-e3fc-861e-7041" typeName="Mantlet">
+          <characteristics>
+            <characteristic name="SPD" typeId="9a1a-1996-43a0-5ebf">-</characteristic>
+            <characteristic name="MAT" typeId="ef7d-7e69-bb45-465a">-</characteristic>
+            <characteristic name="RAT" typeId="0dee-6f34-8704-e237">-</characteristic>
+            <characteristic name="DEF" typeId="7629-6783-48fa-04fb">1</characteristic>
+            <characteristic name="ARM" typeId="8838-aacd-9ec7-99b1">4</characteristic>
+            <characteristic name="DMG" typeId="c150-c260-a91e-5bdb">2</characteristic>
+            <characteristic name="CST" typeId="e127-231f-27ff-e6a4">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e71b-6efb-2a84-0387" name="Wide Spectrum Scanners" hidden="false">
+          <description>While within 2&quot; of this model, friendly models gain the Revelator advantage.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f033-e8a0-7e99-a942" name="Deployable Cover" hidden="false" targetId="7d92-ecde-abcd-cac0" type="rule"/>
+        <infoLink id="4f6a-a67a-fce6-a848" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="3a12-e97e-8b27-56a2" name="Blast Shielding" hidden="false" targetId="4a41-827f-6868-3087" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="659a-9a8d-1393-4806" name="New CategoryLink" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="100b-7975-6442-d2a6" name="Daemon" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5773-a218-77bc-6a35" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e546-43c3-53fc-2eb5" name="Daemon" hidden="false" typeId="cc59-e7be-6377-2748" typeName="Warjack">
+          <characteristics>
+            <characteristic name="SPD" typeId="1413-5833-1ac4-364e">6</characteristic>
+            <characteristic name="STR" typeId="ef6f-3951-7724-cbd5">4</characteristic>
+            <characteristic name="MAT" typeId="7b76-af98-bb5a-e1c9">4</characteristic>
+            <characteristic name="RAT" typeId="eb8d-8cbf-bb66-554b">4</characteristic>
+            <characteristic name="DEF" typeId="b6f0-5339-fc72-593e">3</characteristic>
+            <characteristic name="ARM" typeId="ab4f-1ee8-5665-cc9a">4</characteristic>
+            <characteristic name="DMG" typeId="5361-e1ee-3259-4c39">3</characteristic>
+            <characteristic name="CST" typeId="c638-3794-83aa-d72a">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e62f-e2aa-37d8-9dd2" name="Disruption Engine (Spike)" hidden="false">
+          <description>When this model hits a target with an attack, it can spike to cause enemy Cypher cards on the model to expire.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9f31-d8e1-616a-a053" name="Aegis Field (Charge)" hidden="false" targetId="adcf-4047-c0a2-154b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1abb-099a-62ca-b924" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+        <categoryLink id="993b-8254-bcb2-be15" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4c6e-5126-1927-9159" name="Cortex" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5106-440c-61d6-f989" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1f6-3c8a-b5e3-3630" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c4b9-a3b6-0c51-5927" name="Eidolon" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="afba-87e2-d7c9-25b6" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e1e3-e74d-0308-a657" name="Guardian" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="436a-198b-d5c2-71b9" name="Intercept Driver (Spike)" hidden="false" targetId="ec44-3a92-93db-2564" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5e74-0bb2-bf34-3020" name="Hound" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="6203-8271-9c90-8459" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
+                <infoLink id="e060-47fc-019a-e4f0" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="04ed-dde1-5aa7-0ffa" name="Wraith" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="4774-3b79-dfed-06ff" name="Void Spiral (Charge)" hidden="false">
+                  <description>When this model is hit by an enemy attack while charged, after the attack is resolved, reposition this model anywhere within 2&quot; of it&apos;s current location.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="04b2-d0cb-44e7-b078" name="Hardpoints" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="ecbb-d452-36d4-0214" scope="100b-7975-6442-d2a6" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3730-5a64-b52a-56f4" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="98bb-b4af-d0e2-7746" name="Left Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57fd-9aea-73e1-8601" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="21d3-2867-b5c7-463c" name="Antiminator" hidden="false" collective="false" import="true" targetId="aa7a-2af6-5c47-9152" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="20aa-5039-2459-2fe2" name="Gravitonic Lash" hidden="false" collective="false" import="true" targetId="9ca8-e43f-d085-2956" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="afb5-6a1b-7ef1-9a21" name="Metaperceptor" hidden="false" collective="false" import="true" targetId="524d-1b9a-4bc5-3f3c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="569d-e6e0-653e-7b5f" name="Plasma Blade" hidden="false" collective="false" import="true" targetId="d837-1684-c66d-10af" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bd87-72a0-779d-6206" name="Phase Trajectile Cannon" hidden="false" collective="false" import="true" targetId="7b62-3a5c-c5ec-1b60" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9658-3b72-8ad4-9822" name="Protean Forge" hidden="false" collective="false" import="true" targetId="0b8e-41d8-55b2-6caa" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="83b5-8968-3050-4485" name="Right Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f131-7262-33b6-3f1b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="423f-4f36-363d-6dc0" name="Antiminator" hidden="false" collective="false" import="true" targetId="aa7a-2af6-5c47-9152" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a764-3e8a-9949-c059" name="Gravitonic Lash" hidden="false" collective="false" import="true" targetId="9ca8-e43f-d085-2956" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b792-28ab-6efd-f29a" name="Metaperceptor" hidden="false" collective="false" import="true" targetId="524d-1b9a-4bc5-3f3c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a751-60bb-0b82-eda8" name="Phase Trajectile Cannon" hidden="false" collective="false" import="true" targetId="7b62-3a5c-c5ec-1b60" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ec1d-2305-da70-e466" name="Plasma Blade" hidden="false" collective="false" import="true" targetId="d837-1684-c66d-10af" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="18d6-f8aa-33f7-5059" name="Protean Forge" hidden="false" collective="false" import="true" targetId="0b8e-41d8-55b2-6caa" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d107-4937-ec6b-e46e" name="Back" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b920-e50f-9709-b066" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8bc3-5c7f-87a2-cb76" name="Force Shield Projector" hidden="false" collective="false" import="true" targetId="5c31-15da-628c-9baf" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="61d8-03ed-a106-f692" name="Meteor Cannon" hidden="false" collective="false" import="true" targetId="57aa-3b6c-7828-2b2c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1d74-a78e-b91e-ba6a" name="Nova Cannon" hidden="false" collective="false" import="true" targetId="372a-aee8-775d-8756" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4e57-5fde-a1c4-308a" name="Starfire Array" hidden="false" collective="false" import="true" targetId="6544-4907-6187-cd1f" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ca23-ea8b-0c33-ffc8" name="Sentinel" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8474-281b-a77a-d1f4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ddfe-6e5c-cb50-bb75" name="Sentinel" hidden="false" typeId="cc59-e7be-6377-2748" typeName="Warjack">
+          <characteristics>
+            <characteristic name="SPD" typeId="1413-5833-1ac4-364e">6</characteristic>
+            <characteristic name="STR" typeId="ef6f-3951-7724-cbd5">5</characteristic>
+            <characteristic name="MAT" typeId="7b76-af98-bb5a-e1c9">4</characteristic>
+            <characteristic name="RAT" typeId="eb8d-8cbf-bb66-554b">4</characteristic>
+            <characteristic name="DEF" typeId="b6f0-5339-fc72-593e">2</characteristic>
+            <characteristic name="ARM" typeId="ab4f-1ee8-5665-cc9a">5</characteristic>
+            <characteristic name="DMG" typeId="5361-e1ee-3259-4c39">4</characteristic>
+            <characteristic name="CST" typeId="c638-3794-83aa-d72a">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="684b-f77d-24d5-853b" name="Force Barrier (Spike)" hidden="false">
+          <description>When this model is damaged, it can spike to reduce the damage it would suffer. For each Arc cleared from this model as a result of Force Barrier, reduce the dameage this model takes by 1.</description>
+        </rule>
+        <rule id="f0b4-7af8-b945-9a63" name="Quantum Anchor (Charge)" hidden="false">
+          <description>While charged, this model cannot be moved by a slam or repositioned by an enemy attack.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="797f-40ba-40fa-0a21" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7c58-b4c0-f611-b96c" name="Cortex" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f10-cc18-528a-f580" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87ea-e5e7-b6ac-6f85" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8d13-b205-61b5-8a6c" name="Avatar" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="ce1e-491b-150f-6bd4" name="Eclipse Drive (Spike)" hidden="false" targetId="2ae4-f32f-f0eb-cc1f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b15-82c7-f730-7738" name="Divinator" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="a1c4-c8a4-c085-25c7" name="Smart Lock (Charge)" hidden="false" targetId="6e59-f079-4476-730f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="72bc-5c75-d1e5-7d4c" name="Hellion" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="be9b-161b-d487-5798" name="Relentless" hidden="false" targetId="fd08-4038-ea78-bdd4" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8e8a-1617-6d97-6f8b" name="Numen" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="9ad0-9a7e-8f25-ac02" name="Arc Exchange" hidden="false" targetId="089a-a7eb-cae0-9775" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b4a6-9d08-9e4a-cf9d" name="Hardpoints" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="ecbb-d452-36d4-0214" scope="ca23-ea8b-0c33-ffc8" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ab-865a-d0ec-a617" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5dcb-380c-3fc1-2ef2" name="Chest" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd89-c764-a1f3-0245" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="aaf9-75fe-ac23-036a" name="Chronomorphic Accelerator" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="60b8-037f-64ae-58d7" name="Chronomorphic Accelerator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="5142-7772-16f8-414e" name="Corrosion" hidden="false" targetId="5555-7c59-a346-7406" type="rule"/>
+                    <infoLink id="3094-cc6b-c3cf-c88a" name="Lock Down" hidden="false" targetId="c5f2-b7a9-63fd-e500" type="rule"/>
+                    <infoLink id="094b-d93e-3572-eb05" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                    <infoLink id="57ac-c1ac-4763-9669" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6ee2-cc2a-547e-b779" name="Cyclotronic Razor" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="980b-bf7d-2714-7c39" name="Cyclotronic Razor" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="e633-dfed-b103-af5d" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+                    <infoLink id="75d0-de93-9823-62be" name="Shockwave (Spike)" hidden="false" targetId="33bc-8e3b-8cea-c61e" type="rule"/>
+                    <infoLink id="7d82-9219-aefe-a318" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                    <infoLink id="26f1-fb76-6251-8c90" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5678-53bd-7322-5b1a" name="Dark Star" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="831a-032a-c1d9-521e" name="Dark Star" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+                        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="fb35-1d2c-0523-1ad8" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                    <infoLink id="acc1-126d-7e79-3006" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+                    <infoLink id="3077-ca33-a747-b0e7" name="Singularity Collapse" hidden="false" targetId="4bcb-c9b9-251a-f2a5" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="4.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0ab1-6840-76e9-0df7" name="Eclipse Inducer" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="361f-1dca-300c-2765" name="Eclipse Inducer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="fdce-420f-4fe3-0189" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                    <infoLink id="76ea-f781-aa1c-82f9" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+                    <infoLink id="9d83-0c19-c2d1-15b3" name="Siphon Power" hidden="false" targetId="4da9-a09e-9260-e1ed" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="df34-02ba-ff16-44a5" name="Right Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="941d-99e4-a406-5634" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d9b9-688f-a773-7788" name="Antiminator" hidden="false" collective="false" import="true" targetId="aa7a-2af6-5c47-9152" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2fbf-fb43-28ea-0963" name="Gravitonic Lash" hidden="false" collective="false" import="true" targetId="9ca8-e43f-d085-2956" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="eac7-eacd-24a7-136f" name="Metaperceptor" hidden="false" collective="false" import="true" targetId="524d-1b9a-4bc5-3f3c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a8f6-6d29-978e-58ca" name="Phase Trajectile Cannon" hidden="false" collective="false" import="true" targetId="7b62-3a5c-c5ec-1b60" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bd29-34bd-6919-2dc1" name="Heavy Plasma Blade" hidden="false" collective="false" import="true" targetId="6b7a-bf03-268a-0412" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8581-6979-612d-283d" name="Arcantrik Destabilizer" hidden="false" collective="false" import="true" targetId="8b66-6336-8041-f965" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="b924-a5be-3f30-a2f5" name="Left Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af76-8e4b-b857-2042" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="99f5-8076-d8a8-6744" name="Antiminator" hidden="false" collective="false" import="true" targetId="aa7a-2af6-5c47-9152" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="96ad-d9a5-139a-2230" name="Gravitonic Lash" hidden="false" collective="false" import="true" targetId="9ca8-e43f-d085-2956" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6d0e-f5cf-89c7-5a86" name="Metaperceptor" hidden="false" collective="false" import="true" targetId="524d-1b9a-4bc5-3f3c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0f1f-65b5-6836-5ca7" name="Phase Trajectile Cannon" hidden="false" collective="false" import="true" targetId="7b62-3a5c-c5ec-1b60" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8ec1-4038-3ea0-e31f" name="Heavy Plasma Blade" hidden="false" collective="false" import="true" targetId="6b7a-bf03-268a-0412" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="df65-5138-23a0-6056" name="Arcantrik Destabilizer" hidden="false" collective="false" import="true" targetId="8b66-6336-8041-f965" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="5117-4412-13c9-6e16" name="Back" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fe0-8405-39f4-d362" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fb0b-3244-7f28-d4c5" name="Force Shield Projector" hidden="false" collective="false" import="true" targetId="5c31-15da-628c-9baf" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="602f-4beb-9683-27e1" name="Meteor Cannon" hidden="false" collective="false" import="true" targetId="57aa-3b6c-7828-2b2c" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b76b-7a5e-a0d2-92b5" name="Nova Cannon" hidden="false" collective="false" import="true" targetId="372a-aee8-775d-8756" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c606-6254-db23-0835" name="Starfire Array" hidden="false" collective="false" import="true" targetId="6544-4907-6187-cd1f" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e3cc-7948-324d-764e" name="Astreus, Aeon of the first magnitude" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4be-7514-40da-9442" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="000d-f032-8a1b-54f9" name="Astreus, Aeon of the first magnitude" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">5</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">5</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">4</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">3</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="82b5-bc04-31bf-5150" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="b836-068e-5e2f-f787" name="Realignment Codex (Spike)" hidden="false" targetId="c9e6-a3b3-fe05-7295" type="rule"/>
+        <infoLink id="a0f9-840e-d973-2008" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dd9a-aaaa-502e-b7aa" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+        <categoryLink id="6134-a94c-4668-1be4" name="Units" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1bd1-6561-3ed8-ae2e" name="Plasma Spear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f6-56f2-ffd1-4134" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcaf-c701-5edf-167f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fe18-1ebf-51d9-3916" name="Plasma Spear" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e887-2dcc-7795-250a" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="4600-e30d-8f6c-aa29" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+            <infoLink id="b3ef-0d52-7a41-6f31" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7be1-26d4-cd79-7263" name="Starfire Array" hidden="false" collective="false" import="true" targetId="6544-4907-6187-cd1f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6a7-6796-968b-a01b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2127-2c90-c4a8-9a80" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e82c-bd70-aa39-401d" name="Zenith" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa72-3471-c69e-8692" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b5fc-8596-7de6-2520" name="Zenith" hidden="false" typeId="8503-75a8-8ab2-161b" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="SPD" typeId="d513-8b95-8e8b-9643">8</characteristic>
+            <characteristic name="MAT" typeId="dd71-a3b1-b5d2-4126">3</characteristic>
+            <characteristic name="RAT" typeId="4972-6b8a-4cc9-a39d">4</characteristic>
+            <characteristic name="DEF" typeId="5d4e-e604-9d25-f35d">3</characteristic>
+            <characteristic name="ARM" typeId="5dd6-51ae-08e3-2c18">4</characteristic>
+            <characteristic name="DMG" typeId="804d-3ef2-0e46-d938">4</characteristic>
+            <characteristic name="CST" typeId="c28f-24c8-5446-8b51">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="60c0-c1d5-3287-f4ab" name="Maneuvers" hidden="false">
+          <infoLinks>
+            <infoLink id="6060-94cf-9be8-25d1" name="Sequence Alpha" hidden="false" targetId="9907-2738-dcc2-3ac0" type="rule"/>
+            <infoLink id="273d-f84e-d5ac-59fc" name="Sequence Gamma" hidden="false" targetId="f022-0442-b9f1-442f" type="rule"/>
+            <infoLink id="279f-44bc-bf2b-4308" name="Sequence Omega" hidden="false" targetId="7253-7e80-b558-7d7d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="b598-2992-24fb-fc17" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="11da-c859-62c9-7271" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="253c-6851-83aa-a36c" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8f18-40d3-06df-1898" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5b92-66cc-1ab6-5107" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="695c-6a8b-e153-a589" type="max"/>
+            <constraint field="ecbb-d452-36d4-0214" scope="e82c-bd70-aa39-401d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eea3-0712-e887-e00b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a212-95b6-09be-7b84" name="Force Generator" hidden="false" collective="false" import="true" targetId="758d-b63b-d630-6d41" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="438c-fc26-f5fa-c92e" name="Heavy Antiminator" hidden="false" collective="false" import="true" targetId="5de1-8d9f-615f-136a" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7460-8d90-ab20-4774" name="Nova Cannon" hidden="false" collective="false" import="true" targetId="372a-aee8-775d-8756" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="47c0-ed1f-817f-b9b0" name="Ion Blasters" hidden="false" collective="false" import="true" targetId="6207-47fc-b41d-75ad" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c56f-f7c1-f788-0022" name="Execrator Nix" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff73-0f93-efcb-f27e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e35d-66bd-8a12-66dd" name="Execrator Nix" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">8</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">3</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">5</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">4</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="a91f-5932-83c0-d505" name="Maneuvers" hidden="false">
+          <rules>
+            <rule id="dc62-5a4d-0946-4e18" name="Sequence Epsilon" hidden="false">
+              <description>Remove the activation token from one friendly Empyrean solo within 10&quot; of this model.</description>
+            </rule>
+            <rule id="420a-a0dd-06d7-4b92" name="Sequence Theta" hidden="false">
+              <description>Immediately after this model spikes for the first time during it&apos;s activation, you can charge it with 1 Arc.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="272b-e644-f6d6-96f5" name="Sequence Alpha" hidden="false" targetId="9907-2738-dcc2-3ac0" type="rule"/>
+            <infoLink id="7e7d-9b70-2cc5-6a30" name="Sequence Gamma" hidden="false" targetId="f022-0442-b9f1-442f" type="rule"/>
+            <infoLink id="3b65-ad39-b56c-311b" name="Sequence Gamma" hidden="false" targetId="f022-0442-b9f1-442f" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="3448-b61a-91e7-c742" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="e8a4-3107-2733-c2ce" name="Arcanum Module" hidden="false" targetId="e1cf-527f-2655-b7ed" type="rule"/>
+        <infoLink id="cee9-3728-fb5e-1c61" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
+        <infoLink id="0f22-1c2a-2b3e-5af3" name="Gate Launcher (Spike)" hidden="false" targetId="e94a-94b2-5aeb-5014" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="352c-7692-17df-b75b" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="996a-77b5-b266-f1ad" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb54-ec5e-3e85-e8da" type="max"/>
+            <constraint field="ecbb-d452-36d4-0214" scope="c56f-f7c1-f788-0022" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb56-595a-089e-d8c9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1e2c-c478-6e6b-bd4a" name="Shadow Matrix" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="c86d-1dc9-379b-a6e6" name="Shadow Matrix" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+                    <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="305e-8d93-3b28-e6ce" name="Soul Seeker" hidden="false">
+                  <description>This model can target warrior models with this weapon without line of sight.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="d4b1-c864-b601-1c45" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                <infoLink id="13e6-1e36-7df1-632f" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+                <infoLink id="1df1-f713-ab84-421c" name="Dislocator (Spike)" hidden="false" targetId="ebb5-c4d8-2797-e523" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="5e21-9e32-6299-82f0" name="Force Generator" hidden="false" collective="false" import="true" targetId="758d-b63b-d630-6d41" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="23ea-e549-474d-fc5e" name="Heavy Antiminator" hidden="false" collective="false" import="true" targetId="5de1-8d9f-615f-136a" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a4de-1cc2-820d-8a37" name="Nova Cannon" hidden="false" collective="false" import="true" targetId="372a-aee8-775d-8756" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="33ed-9a34-a3b1-5bd5" name="Ion Blasters" hidden="false" collective="false" import="true" targetId="6207-47fc-b41d-75ad" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="f926-ec16-e9d3-c4fa" name="Doctor Mira Hurst" hidden="false" collective="false" import="true" targetId="afbe-3ad8-68cc-021f" type="selectionEntry"/>
+    <entryLink id="6106-46a1-8296-7730" name="Cyphers" hidden="false" collective="false" import="true" targetId="3961-255e-7446-6cc4" type="selectionEntry"/>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="b90c-c2c1-f3ab-abca" name="Tentacle Strike" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2857-b1d2-55a3-1112" name="Tentacle Strike" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3729-b410-1076-2b4b" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="c0a0-696c-bdac-2f80" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa7a-2af6-5c47-9152" name="Antiminator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3f32-5eee-0c42-fff1" name="Antiminator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a398-53f3-94fe-d3df" name="Malefactor" hidden="false" targetId="cbff-67cf-93ba-4651" type="rule"/>
+        <infoLink id="e296-eebe-676d-f772" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="ed6f-19dc-1cc5-2000" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9ca8-e43f-d085-2956" name="Gravitonic Lash" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a957-f885-54ed-3e9e" name="Gravitonic Lash" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">6</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="147d-9e01-d213-8db9" name="Winch" hidden="false" targetId="92ca-26e8-fd63-05ce" type="rule"/>
+        <infoLink id="1f27-1795-dce2-7054" name="Range Amplifier (Charge)" hidden="false" targetId="e532-a22c-5f39-54d3" type="rule"/>
+        <infoLink id="9884-d7cc-0d8a-7866" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="524d-1b9a-4bc5-3f3c" name="Metaperceptor" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="efa4-f57e-3754-9530" name="Metaperceptor" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">-</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6026-d3b1-b40d-8eb3" name="Advanced Optics" hidden="false" targetId="067d-b201-437d-8185" type="rule"/>
+        <infoLink id="3888-9808-d617-c9bf" name="Revelator" hidden="false" targetId="c8f4-25c2-f013-c8b2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b62-3a5c-c5ec-1b60" name="Phase Trajectile Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a72e-7286-7edf-60c2" name="Phase Trajectile Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="fe00-a5ca-86ac-f810" name="Phase Trajectiles (Charge)" hidden="false">
+          <description>While this model is charged, ignore line of sight and cover when attacking with this weapon.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9346-8316-63a3-a887" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="351f-0397-4f78-8de5" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d837-1684-c66d-10af" name="Plasma Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2634-eba6-2496-6aa4" name="Plasma Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a162-4938-de5e-52b6" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="0dc9-a7a3-c628-7fa6" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="20b8-95bf-4d9f-34b6" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b8e-41d8-55b2-6caa" name="Protean Forge" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b5fc-adb2-d4ee-195c" name="Protean Forge" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="75fa-8793-aa57-cb20" name="Attack Mode" hidden="false">
+          <rules>
+            <rule id="8f8a-014f-9331-5766" name="Range Extender" hidden="false">
+              <description>This weapon gains +2 RNG.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="65dd-2ad9-ad87-404b" name="Armor Piercing" hidden="false" targetId="4a62-dd5f-b896-d12c" type="rule"/>
+            <infoLink id="b907-c4b5-f8c7-9a46" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="3c55-a910-c8e3-ea9b" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="4fea-f26f-2f13-bb89" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c31-15da-628c-9baf" name="Force Shield Projector" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="dc4c-6c55-cf0e-2c60" name="Force Shield Projector" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0ef0-afab-341c-65f3" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="8d37-4a4c-b9ab-a366" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="bf36-4eee-ca4f-e6e1" name="Shield" hidden="false" targetId="ced4-3c62-3606-31ca" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="57aa-3b6c-7828-2b2c" name="Meteor Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4206-ae32-088e-dc1b" name="Meteor Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6f6b-d4cf-baf6-7d7f" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="65b1-1a60-84a2-6d20" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="c11a-6efb-337d-e4c2" name="Force Ram (Spike)" hidden="false" targetId="c2f8-48d9-d6ed-1bdf" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="372a-aee8-775d-8756" name="Nova Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c617-a868-6e69-277f" name="Nova Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="69fe-8d59-1192-7083" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="7c3a-7a7a-472f-d6bb" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+        <infoLink id="d9d7-93f3-9e02-2ed4" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+        <infoLink id="e870-e4ce-5080-952a" name="Spray" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6544-4907-6187-cd1f" name="Starfire Array" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b4f2-b6ab-7eca-ed36" name="Starfire Array" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cb77-f590-148e-54c6" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="2002-6d96-3fef-6ccf" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="df2f-0cbb-5352-4bfc" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="5c6a-3759-91c2-c784" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b7a-bf03-268a-0412" name="Heavy Plasma Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7bd9-7c8a-7b81-ea28" name="Heavy Plasma Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b4d7-0cb1-3db2-5543" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+        <infoLink id="1ed4-6e1c-9c79-7b1e" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="c611-a1b9-9df2-2efa" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b66-6336-8041-f965" name="Arcantrik Destabilizer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6e4e-b59d-122e-c1fb" name="Arcantrik Destabilizer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0a5d-6f61-317a-c9a6" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="2de7-7ef5-c363-c1ee" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="cffa-17f1-2634-96d6" name="Null Strike" hidden="false" targetId="f174-cd6d-3802-1cbc" type="rule"/>
+        <infoLink id="6382-ec02-54b6-967e" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="758d-b63b-d630-6d41" name="Force Generator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="79bc-ff0e-f826-4e1c" name="Force Generator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0987-3548-f6ae-4991" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="dfc6-bea0-8c23-bc22" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="f652-b455-f4d0-345f" name="Force Ram (Spike)" hidden="false" targetId="c2f8-48d9-d6ed-1bdf" type="rule"/>
+        <infoLink id="be6a-020e-0db8-c771" name="Shield" hidden="false" targetId="ced4-3c62-3606-31ca" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5de1-8d9f-615f-136a" name="Heavy Antiminator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c962-d570-aa1d-51be" name="Heavy Antiminator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c510-8c2c-6395-93ef" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="70fb-f293-cefd-cfd4" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+        <infoLink id="b6b6-e099-db3c-5ee9" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="cb34-e4de-fe7f-d1fc" name="Malefactor" hidden="false" targetId="cbff-67cf-93ba-4651" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6207-47fc-b41d-75ad" name="Ion Blasters" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fbd-b78a-51a6-513b" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f3-3a2d-2734-e2ce" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2947-4209-36b4-d064" name="Ion Blasters" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f40b-7ead-dfe7-8ae2" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="62b6-b054-3191-0fc9" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="2e20-f85e-c0ff-0cdd" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+        <infoLink id="bb37-9284-3ac1-e81a" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="e1cf-527f-2655-b7ed" name="Arcanum Module" hidden="false">
+      <description>When you target this unit with a Cypher, you can charge it with up to 1 Arc if it is not already charged. When this unit is targeted by an enemy Fury, after the attack is resolved you can charge this unit with up to 1 Arc if it is not already charged.</description>
+    </rule>
+    <rule id="2ae4-f32f-f0eb-cc1f" name="Eclipse Drive (Spike)" hidden="false">
+      <description>This unit can spike at the end of it&apos;s activation to use Eclipse Drive. If it does so, do not place an activation token on this unit at the end of it&apos;s activation.</description>
+    </rule>
+    <rule id="9d24-af6a-5a5f-296b" name="Havoc Engine (Charge)" hidden="false">
+      <description>Whule charged, if this model destraoys an enemy module with an attack during it&apos;s activation, it  can immediately make an additional attack with another weapon. This model cannot attack with the same weapon twice during it&apos;s activation as a result of Havoc Engine.</description>
+    </rule>
+    <rule id="9907-2738-dcc2-3ac0" name="Sequence Alpha" hidden="false">
+      <description>This model does not gain an activation token at the end of it&apos;s activation.</description>
+    </rule>
+    <rule id="f022-0442-b9f1-442f" name="Sequence Gamma" hidden="false">
+      <description>This model adds one POWER dies to attack rolls against models with Flight. Additionally, this model gains +1 on DEF rolls against attacks made by models with Flight. The maneuver expires at the beginning of this model&apos;s next turn.</description>
+    </rule>
+    <rule id="7253-7e80-b558-7d7d" name="Sequence Omega" hidden="false">
+      <description>THis model gains Stealth but cannot target models without Flight with attacks. A model with Stealth cannot be targeted by attacks made by models more than 8&quot; away. This maneuver expires at the beginning of this model&apos;s next activation.</description>
+    </rule>
+  </sharedRules>
+</catalogue>

--- a/Iron_Star_Alliance.cat
+++ b/Iron_Star_Alliance.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ac83-1714-49af-721e" name="Iron Star Alliance" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ac83-1714-49af-721e" name="Iron Star Alliance" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="b0e6-c6b9-4e6f-7c99" name="Firebrand" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -34,25 +34,31 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="47b5-af54-cff7-eb45" name="&apos;Jack Hunter" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="7447-05d3-15a0-dec8" name="&apos;Jack Hunter (Spike)" hidden="false" targetId="43d0-e95c-e7b5-3bb3" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="067a-8c71-80f7-e2f8" name="&apos;Jack Hunter (Spike)" hidden="false">
+                  <description>Once per activation, this model can spike to use &apos;Jack Hunter. That activation, this model gains +3 action dice on its attack rolls targeting enemy warjacks.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1c69-57b5-febc-1904" name="Reflex Cortex" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="d598-89a9-6ea5-a297" name="Heightened Reflexes" hidden="false" targetId="4eaf-902d-3737-14fe" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="39d1-33c5-b617-13dc" name="Heightened Reflexes" hidden="false">
+                  <description>When this model is targeted by an attack, after the attack is resolved, it can move up to 3&quot;.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="289c-48cb-0dd8-7ae2" name="Neural Web" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="178c-bd13-2738-1c9c" name="Neural Web" hidden="false" targetId="a862-92a3-7800-6e64" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="6383-1037-ccbe-d917" name="Neural Web" hidden="false">
+                  <description>This model gains a cumulative +1 MAT bonus for each other friendly unit with 5&quot;</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -83,7 +89,7 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="e772-9ee1-231f-1580" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="1470-2f06-63ec-db51" type="selectionEntry">
+                <entryLink id="e772-9ee1-231f-1580" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="30a2-1923-ff65-6b4e" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
@@ -202,12 +208,24 @@
         <infoLink id="4824-a6bc-f7d0-8dbc" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="5007-fbc6-b28d-101f" name="Divination Lock (Spike)" hidden="false" targetId="4e5f-ca6e-a6ae-da51" type="rule"/>
         <infoLink id="842e-db5c-bc71-cb48" name="Reflex Accelerator (Charge)" hidden="false" targetId="2cb7-ba4d-ce4d-4e27" type="rule"/>
-        <infoLink id="3d24-f87e-9ec1-bce8" name="Assault Rifle" hidden="false" targetId="a669-670b-4692-9886" type="profile"/>
-        <infoLink id="c7d2-a4a3-7dd4-b222" name="Bayonet" hidden="false" targetId="d5e7-173e-2edd-379f" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7e6c-5716-7eb5-a2f6" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="9c1b-7858-0040-5357" name="Bayonet" hidden="false" collective="false" import="true" targetId="aadd-fa45-1db9-5327" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2626-1ce6-6408-c93b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a398-b3f5-9b2e-1832" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d129-eb8a-b636-ab35" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="fca2-fc5f-d8fc-f2ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d0f-8330-9d56-1aed" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36aa-ceca-9752-2a82" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -235,13 +253,24 @@
         <infoLink id="473a-1e4d-8c2d-6ff9" name="Arcantrik Amplifier (Charge)" hidden="false" targetId="a4ab-9b99-4e38-42f9" type="rule"/>
         <infoLink id="8a55-b781-f91d-5650" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="0600-c1f3-45a2-51af" name="Realignment Codex (Spike)" hidden="false" targetId="c9e6-a3b3-fe05-7295" type="rule"/>
-        <infoLink id="839d-24d3-e9ab-36d8" name="Null Strike" hidden="false" targetId="f174-cd6d-3802-1cbc" type="rule"/>
-        <infoLink id="60ef-771d-9fca-cc8e" name="Handgun" hidden="false" targetId="fa30-c94b-dcf7-e67e" type="profile"/>
-        <infoLink id="db79-0c3e-92d5-4299" name="Null Hammer" hidden="false" targetId="b8e5-a35e-a3f3-26c5" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cbd3-737f-486a-35d9" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="e360-8a86-ce3a-ba28" name="Null Hammer" hidden="false" collective="false" import="true" targetId="c703-3325-4b91-fb46" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d44f-b315-2ce3-19d9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="437f-489d-a18c-a53a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="e63a-da03-6577-29cb" name="Handgun" hidden="false" collective="false" import="true" targetId="2335-aa3e-baca-5120" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9279-3710-0488-5b83" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbfc-f63d-05db-4383" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -268,13 +297,24 @@
         <infoLink id="29a0-dc88-3bb3-f65e" name="Command Interface (Paladin) (Spike)" hidden="false" targetId="f617-cd36-a4f8-cd90" type="rule"/>
         <infoLink id="a715-b364-df53-d99c" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="5e58-02ab-1b86-0f67" name="Reflex Accelerator (Charge)" hidden="false" targetId="2cb7-ba4d-ce4d-4e27" type="rule"/>
-        <infoLink id="57af-a5ac-e5a4-ce2d" name="Fusion Sword" hidden="false" targetId="da37-9cac-c150-96b5" type="profile"/>
-        <infoLink id="f9cf-890b-d64f-d404" name="Pulse Cannon" hidden="false" targetId="9828-e26b-6ead-00a8" type="profile"/>
-        <infoLink id="1448-8908-21f3-5cb2" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="31b5-c729-f820-8ee8" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="e925-03f2-5067-b86f" name="Pulse Cannon" hidden="false" collective="false" import="true" targetId="c688-ecde-1912-57bb" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f13-4bfe-b0c7-2563" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8496-8d0b-3911-ab77" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0b0a-c169-55f8-2830" name="Fusion Sword" hidden="false" collective="false" import="true" targetId="dd0d-1af9-772b-2a66" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e61b-a50f-e81f-3ceb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2974-3a9a-1f35-2e6f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -366,7 +406,7 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="754a-de37-0ab6-eb75" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="1470-2f06-63ec-db51" type="selectionEntry">
+                <entryLink id="754a-de37-0ab6-eb75" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="30a2-1923-ff65-6b4e" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
@@ -410,7 +450,7 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="d095-a8ed-b87d-f622" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="1470-2f06-63ec-db51" type="selectionEntry">
+                <entryLink id="d095-a8ed-b87d-f622" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="30a2-1923-ff65-6b4e" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
@@ -431,16 +471,16 @@
     </selectionEntry>
     <selectionEntry id="8e55-b58c-569a-ef97" name="Paladin Aegis" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="increment" field="cd1a-7a3f-d88c-ff2e" value="1.0">
+        <modifier type="increment" field="1388-67fb-7f8a-3bab" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bdd8-99b0-f98b-92b5" repeats="1" roundUp="false"/>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b723-e423-c97d-0324" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="03a1-b25f-9844-fd98" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bdd8-99b0-f98b-92b5" repeats="1" roundUp="false"/>
           </repeats>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd1a-7a3f-d88c-ff2e" type="max"/>
-        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1388-67fb-7f8a-3bab" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1388-67fb-7f8a-3bab" type="max"/>
       </constraints>
       <profiles>
         <profile id="db9e-a008-4094-9db8" name="Paladin Aegis" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
@@ -459,13 +499,18 @@
         <infoLink id="48cb-b1cd-4347-85fc" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="f132-338a-e01f-e34c" name="Force Field (Charge)" hidden="false" targetId="cfe1-9227-7692-7b68" type="rule"/>
         <infoLink id="30f9-9604-4d81-ae85" name="Attachment (Paladin)" hidden="false" targetId="d921-b7e2-3db0-7b0c" type="rule"/>
-        <infoLink id="4b92-7be2-cdda-ac7b" name="Force Generator" hidden="false" targetId="45f8-4b97-fbe2-b4f7" type="profile"/>
-        <infoLink id="7b05-8023-0a3a-687a" name="Force Ram (Spike)" hidden="false" targetId="c2f8-48d9-d6ed-1bdf" type="rule"/>
-        <infoLink id="cc1f-b353-42a4-97ec" name="Lock Down" hidden="false" targetId="c5f2-b7a9-63fd-e500" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2abb-9d50-7e33-9012" name="New CategoryLink" hidden="false" targetId="fa79-7113-8f14-037f" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="e2d4-9f24-a674-e5b6" name="Force Generator" hidden="false" collective="false" import="true" targetId="1464-f795-756d-1758" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1277-594b-9593-41cb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9336-8eaf-f880-46a3" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -490,21 +535,24 @@
       <infoLinks>
         <infoLink id="e99f-5164-46cf-e19a" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="9cf8-e0a0-49a6-ffaa" name="Smart Lock (Charge)" hidden="false" targetId="6e59-f079-4476-730f" type="rule"/>
-        <infoLink id="7281-5616-be1c-b0e1" name="Hunter-Killer Salvo (Spike)" hidden="false" targetId="8e98-cf4d-0227-ff7b" type="rule"/>
-        <infoLink id="3b94-c824-268b-d930" name="Harbinger Cannon" hidden="false" targetId="34fc-3815-d467-5147" type="profile"/>
-        <infoLink id="f537-55a5-aa12-abd3" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="7281-5616-be1c-b0e1" name="Hunter-Killer Rounds (Spike)" hidden="false" targetId="cb00-7571-a4fd-84d6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c2ff-8a1c-d825-9e13" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="6a64-1cfd-81cd-88e4" name="Harbinger Cannon" hidden="false" collective="false" import="true" targetId="30a2-1923-ff65-6b4e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1367-b36a-c1b4-2937" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e3-b70b-5627-f482" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4a46-184d-1976-cacc" name="Justicar Voss" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44e0-f554-d4a6-ec0d" type="max"/>
-      </constraints>
+    <selectionEntry id="4a46-184d-1976-cacc" name="Justicar Voss" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="2f3c-6004-a7b5-7c1b" name="Justicar Voss" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
           <characteristics>
@@ -520,17 +568,278 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="d00d-3203-97f1-2e58" name="Arc Blade" hidden="false" targetId="a3fe-e59d-e3af-c0fd" type="profile"/>
-        <infoLink id="bb92-d3fa-4fbf-bdf7" name="Arc Blade" hidden="false" targetId="a3fe-e59d-e3af-c0fd" type="profile"/>
         <infoLink id="9568-7a4c-1ac5-93e1" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
         <infoLink id="52f1-946b-080f-c5fe" name="Relentless" hidden="false" targetId="fd08-4038-ea78-bdd4" type="rule"/>
         <infoLink id="bf87-d63d-15fa-0621" name="Void Shifter (Charge)" hidden="false" targetId="a368-0229-d52b-99db" type="rule"/>
         <infoLink id="a791-2022-c4c8-4138" name="Void Jumper (Spike)" hidden="false" targetId="8f06-26c7-6306-c0b7" type="rule"/>
         <infoLink id="cca3-1c38-4c3a-1bdc" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
-        <infoLink id="ff79-4439-358f-7c53" name="Attack Mode (Arc Blades)" hidden="false" targetId="c4ab-5e42-23af-4af5" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5c1a-9072-c0a4-d58e" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8ff6-e8a1-dd6c-d29d" name="Arc Blade" hidden="false" collective="false" import="true" targetId="8600-d8ad-0383-4869" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="849f-c675-fb61-d137" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4abc-5abb-d1e8-f8c8" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03a1-b25f-9844-fd98" name="Paladin Defenders" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3beb-515e-c286-3b2c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8ff1-54ec-5a4a-00b0" name="Paladin Defenders" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">6</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">4</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0865-0e05-3a39-4679" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="9a73-b6dd-dd1a-2961" name="Intercept Driver (Spike)" hidden="false" targetId="ec44-3a92-93db-2564" type="rule"/>
+        <infoLink id="0914-ef4a-266e-3ba1" name="Force Projector (Charge)" hidden="false" targetId="ee53-15d2-f2a6-4545" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0788-c2dd-6894-375d" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="33da-01ca-9f9d-39fb" name="Fusion Spear" hidden="false" collective="false" import="true" targetId="17f0-dd6f-101f-40a4" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d5-1796-7b00-4f4e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ad-930f-6a29-a8b6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e7c4-ca74-4b10-b715" name="Paladin Siegebreaker" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5898-05a3-d4df-fa85" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="34ae-9ed5-92fb-faab" name="Paladin Siegebreaker" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">4</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">4</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">3</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">2</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">3</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c9bc-2590-e53a-ac02" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="05e0-d408-1047-8087" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
+        <infoLink id="856d-c258-bb96-b862" name="Arcantrik Turbine (Charge)" hidden="false" targetId="e013-6944-6609-e65c" type="rule"/>
+        <infoLink id="83b8-90b4-8fc0-46c4" name="Power Focus (Spike)" hidden="false" targetId="87fe-98b8-3637-f640" type="rule"/>
+        <infoLink id="c0cd-650d-dc0a-84f0" name="Dominion Converter" hidden="false" targetId="f894-5e6e-fa49-2330" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a66e-9aaa-7b92-293a" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f8ed-018a-4259-9486" name="Radliffe X9" hidden="false" collective="false" import="true" targetId="8019-d27d-6a60-e3b0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0c6-759a-dc72-2df0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc0e-5031-4f14-a986" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0e8b-46e3-4830-1e51" name="Castigator Missiles" hidden="false" collective="false" import="true" targetId="25ba-40b2-f2fa-159f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5787-bea5-0655-8628" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a340-c2f2-25c2-191e" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1d2d-57ae-fb8a-5b6e" name="Fusion Sword" hidden="false" collective="false" import="true" targetId="dd0d-1af9-772b-2a66" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0327-c133-b888-ea14" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc8d-e516-2ee8-fc8e" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f46-b8db-89b7-2399" name="Interceptor" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21dc-09db-9605-a2e9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e7a8-e290-2bf9-3163" name="Interceptor" hidden="false" typeId="8503-75a8-8ab2-161b" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="SPD" typeId="d513-8b95-8e8b-9643">9</characteristic>
+            <characteristic name="MAT" typeId="dd71-a3b1-b5d2-4126">3</characteristic>
+            <characteristic name="RAT" typeId="4972-6b8a-4cc9-a39d">4</characteristic>
+            <characteristic name="DEF" typeId="5d4e-e604-9d25-f35d">4</characteristic>
+            <characteristic name="ARM" typeId="5dd6-51ae-08e3-2c18">4</characteristic>
+            <characteristic name="DMG" typeId="804d-3ef2-0e46-d938">3</characteristic>
+            <characteristic name="CST" typeId="c28f-24c8-5446-8b51">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="990e-7d39-6f4e-3bde" name="Maneuvers" hidden="false">
+          <infoLinks>
+            <infoLink id="8af7-846c-3150-f764" name="Evasive Action" hidden="false" targetId="9b9d-84ff-3a95-2643" type="rule"/>
+            <infoLink id="8b02-0e9b-3726-6c6b" name="Full Burn" hidden="false" targetId="8cd5-24b7-348a-7b0e" type="rule"/>
+            <infoLink id="4367-301c-a9fd-ca34" name="Sky Hunter" hidden="false" targetId="ffb3-1376-f6a4-e56b" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="6041-8dab-5fe1-bf9b" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="e29f-d66c-e3f3-6dae" name="Evasion Drive (Charge)" hidden="false" targetId="924c-5fcf-2a4f-e516" type="rule"/>
+        <infoLink id="0039-c8d5-cd7b-5862" name="High Performance (Spike)" hidden="false" targetId="333f-86b4-6f91-3619" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="339c-bfac-1cd8-850a" name="Units" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="613c-f49e-8ff1-11e8" name="Hardpoints" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="ecbb-d452-36d4-0214" scope="9f46-b8db-89b7-2399" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9d3-295c-41ca-48e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131e-2bed-706a-8d6c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="129d-18cc-f18c-c652" name="Force Cannon" hidden="false" collective="false" import="true" targetId="ae2e-1ebb-80ce-24ed" type="selectionEntry"/>
+            <entryLink id="46c3-fac3-89d0-1cea" name="Immolator" hidden="false" collective="false" import="true" targetId="a180-ac56-f460-8709" type="selectionEntry"/>
+            <entryLink id="ff61-cec3-a3f0-f517" name="Tempest Cannon" hidden="false" collective="false" import="true" targetId="cf92-181b-8809-789e" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e650-ffc0-0caf-c768" name="Fixed Guns" hidden="false" collective="false" import="true" targetId="7e79-412e-c223-d0a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9dc-3d66-84d9-89fe" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="137c-d11b-6066-b235" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1efd-1c32-301c-f207" name="Duchess" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33e6-470b-b129-b09a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ee1a-fcd3-69fa-f5d0" name="Duchess" hidden="false" typeId="8503-75a8-8ab2-161b" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="SPD" typeId="d513-8b95-8e8b-9643">9</characteristic>
+            <characteristic name="MAT" typeId="dd71-a3b1-b5d2-4126">3</characteristic>
+            <characteristic name="RAT" typeId="4972-6b8a-4cc9-a39d">5</characteristic>
+            <characteristic name="DEF" typeId="5d4e-e604-9d25-f35d">5</characteristic>
+            <characteristic name="ARM" typeId="5dd6-51ae-08e3-2c18">4</characteristic>
+            <characteristic name="DMG" typeId="804d-3ef2-0e46-d938">3</characteristic>
+            <characteristic name="CST" typeId="c28f-24c8-5446-8b51">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="098a-87e1-317f-245e" name="Maneuvers" hidden="false">
+          <rules>
+            <rule id="4bfd-4bda-f4fb-c216" name="Pursuit Intercept" hidden="false">
+              <description>This model adds two POWER dice to attack rolls against enemy models with flight. When this model destroys one or more enemy models with an attack, after the attack is resolved this model can immediately move up to 3&quot;. The maneuver expires at the end of this activation.</description>
+            </rule>
+            <rule id="8cb5-40b3-c8fb-283a" name="Strafing Run" hidden="false">
+              <description>This model&apos;s Fixed Guns ranged weapon gains Strafe. Additionally, this model adds one power die to attack rolls against enemy warrior models. This maneuver expires at the end of this activation.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="a042-7826-5520-97c1" name="Evasive Action" hidden="false" targetId="9b9d-84ff-3a95-2643" type="rule"/>
+            <infoLink id="7fdf-2d1b-a2e5-fd6c" name="Full Burn" hidden="false" targetId="8cd5-24b7-348a-7b0e" type="rule"/>
+            <infoLink id="84e2-dab1-a92a-78cf" name="Sky Hunter" hidden="false" targetId="ffb3-1376-f6a4-e56b" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="3838-f392-88af-675d" name="Flight" hidden="false" targetId="62eb-2d21-2a6c-8b68" type="rule"/>
+        <infoLink id="e4bb-6f68-7532-9d23" name="Evasion Drive (Charge)" hidden="false" targetId="924c-5fcf-2a4f-e516" type="rule"/>
+        <infoLink id="38e1-a882-2aba-4ab9" name="High Performance (Spike)" hidden="false" targetId="333f-86b4-6f91-3619" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2840-0adb-26a0-4a78" name="Heroes" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+        <categoryLink id="3a45-8fee-3ab1-122e" name="Heroes" hidden="false" targetId="cc26-f6fc-643b-1352" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bc76-fecc-eb10-7897" name="Hardpoints" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e58-652e-7dbb-9c16" type="max"/>
+            <constraint field="ecbb-d452-36d4-0214" scope="1efd-1c32-301c-f207" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b20e-49c8-8439-04d6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4c15-f3db-f7e7-1ee4" name="Null Torpedo" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="ab0a-e6b5-3612-bd12" name="Force Cannon" hidden="false" collective="false" import="true" targetId="ae2e-1ebb-80ce-24ed" type="selectionEntry"/>
+            <entryLink id="7cfc-5870-c8d7-9fa8" name="Immolator" hidden="false" collective="false" import="true" targetId="a180-ac56-f460-8709" type="selectionEntry"/>
+            <entryLink id="5403-fdc9-22dd-fd00" name="Tempest Cannon" hidden="false" collective="false" import="true" targetId="cf92-181b-8809-789e" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="137b-942a-8999-ab70" name="Fixed Guns" hidden="false" collective="false" import="true" targetId="7e79-412e-c223-d0a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8604-1520-b7c9-7e14" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec3a-bf81-0543-8912" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5913-9c1f-bef6-a7cc" name="Force Barrier" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8c2-3956-1bc1-17b6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bd29-9040-6480-2dd2" name="Force Barrier" hidden="false" typeId="f21f-e3fc-861e-7041" typeName="Mantlet">
+          <characteristics>
+            <characteristic name="SPD" typeId="9a1a-1996-43a0-5ebf">-</characteristic>
+            <characteristic name="MAT" typeId="ef7d-7e69-bb45-465a">-</characteristic>
+            <characteristic name="RAT" typeId="0dee-6f34-8704-e237">-</characteristic>
+            <characteristic name="DEF" typeId="7629-6783-48fa-04fb">1</characteristic>
+            <characteristic name="ARM" typeId="8838-aacd-9ec7-99b1">4</characteristic>
+            <characteristic name="DMG" typeId="c150-c260-a91e-5bdb">2</characteristic>
+            <characteristic name="CST" typeId="e127-231f-27ff-e6a4">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c378-14e1-2430-7bf2" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="da74-845b-7786-f7d2" name="Deployable Cover" hidden="false" targetId="7d92-ecde-abcd-cac0" type="rule"/>
+        <infoLink id="8344-88d1-de51-aea8" name="Field Reinforcement" hidden="false" targetId="454e-3b8b-3de2-856d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6810-2c10-dbf7-4657" name="Mantlet" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
@@ -541,13 +850,27 @@
     <entryLink id="7416-4cde-e073-481e" name="Cyphers" hidden="false" collective="false" import="true" targetId="3961-255e-7446-6cc4" type="selectionEntry"/>
     <entryLink id="76c2-fc93-08bd-252d" name="Baron Cassius Mooregrave" hidden="false" collective="false" import="true" targetId="06b9-ea95-5cd2-5bd2" type="selectionEntry"/>
     <entryLink id="219d-2dda-4024-16ed" name="Voitek Sudal, Bounty Hunter" hidden="false" collective="false" import="true" targetId="d57b-15ce-482f-c16c" type="selectionEntry"/>
+    <entryLink id="d8e0-8f03-5bb7-7389" name="Doctor Mira Hurst" hidden="false" collective="false" import="true" targetId="afbe-3ad8-68cc-021f" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="620f-eebd-5682-893a" name="Repulsor Shield" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7e4b-7ab2-48ff-515a" name="Repulsor Shield" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b165-e521-7959-b64c" name="Repulsor Ram (Spike)" hidden="false">
+          <description>When this model is hit by a melee attack, after the attack is resolved, this model can spike to use Repulsor Ram. The attacking model is immediately slammed 3&quot; directly away from this model. Collateral damage is equal to the POW of the attacking model&apos;s melee weapon.</description>
+        </rule>
+      </rules>
       <infoLinks>
-        <infoLink id="450e-2127-e609-37c6" name="Repulsor Shield (Spike)" hidden="false" targetId="8d87-7a73-e467-d6cd" type="rule"/>
         <infoLink id="63d3-0f6d-ffcb-20fa" name="Shield" hidden="false" targetId="ced4-3c62-3606-31ca" type="rule"/>
-        <infoLink id="a486-ca92-bcf5-9ded" name="Repulsor Shield" hidden="false" targetId="ec42-ff05-a4f4-2c0a" type="profile"/>
+        <infoLink id="6a09-721f-3c45-f4e7" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="0637-e1b1-b037-38a6" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
@@ -557,44 +880,74 @@
       <infoLinks>
         <infoLink id="2415-e5a7-49a7-0c0d" name="Power Attack (Spike)" hidden="false" targetId="f45d-f7bc-3379-d648" type="rule"/>
         <infoLink id="4209-f542-5dc8-fa2e" name="Fusion Glaive" hidden="false" targetId="c07f-caf7-6a51-a23e" type="profile"/>
+        <infoLink id="7c63-fb50-027b-d0b4" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="c7ba-5940-08f4-a35e" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6cad-6f61-b590-c013" name="Assault Rifle &amp; Bayonet" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="08de-62a5-f0d5-de17" name="Assault Rifle" hidden="false" targetId="a669-670b-4692-9886" type="profile"/>
-        <infoLink id="75de-3196-98cd-f2f7" name="Bayonet" hidden="false" targetId="d5e7-173e-2edd-379f" type="profile"/>
-      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="1422-3838-2a9e-9be2" name="Bayonet" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30a5-fe94-9d07-04c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8d1-ce77-7813-70a1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9fe3-3df7-3104-5dae" name="Bayonet" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8c4f-710e-94cf-2e79" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="2e42-60fa-9d3b-84e8" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="c6f7-4e4e-14ce-c066" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="fca2-fc5f-d8fc-f2ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fe6-854a-5f33-cd0c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0111-7faa-7c30-c7cb" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1470-2f06-63ec-db51" name="Harbinger Cannon" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1b0f-a528-b42f-c992" name="Hunter-Killer Rounds (Spike)" hidden="false" targetId="cb00-7571-a4fd-84d6" type="rule"/>
-        <infoLink id="09f5-f9e1-b259-1319" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
-        <infoLink id="3b7f-2042-b0ce-5253" name="Harbinger Cannon" hidden="false" targetId="34fc-3815-d467-5147" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a3b7-d885-c0ce-0023" name="Null Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="37a0-7360-0ff9-a1f9" name="Null Strike" hidden="false" targetId="f174-cd6d-3802-1cbc" type="rule"/>
         <infoLink id="f6c5-5e27-f390-6d9c" name="Null Cannon" hidden="false" targetId="060f-6de4-deeb-6f29" type="profile"/>
+        <infoLink id="54b2-fa21-89c8-c536" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+        <infoLink id="6ec8-f600-8c54-cc35" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6485-a0c6-16ce-6791" name="Starburst Missiles" hidden="false" collective="false" import="true" type="upgrade">
+      <infoGroups>
+        <infoGroup id="a304-3c22-4d69-1f09" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="8ae1-fa27-6284-c680" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="bc68-54f1-f1dd-d7b7" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
       <infoLinks>
         <infoLink id="564a-df0b-c67a-a8cf" name="Starburst Missiles" hidden="false" targetId="07a0-694d-2123-77ca" type="profile"/>
         <infoLink id="354d-f0e4-9c8c-d21b" name="Targeter (Charge)" hidden="false" targetId="1891-8584-c483-7085" type="rule"/>
         <infoLink id="2d1a-ec6c-644a-716d" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="092a-e611-9dc3-8a74" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
@@ -604,6 +957,8 @@
       <infoLinks>
         <infoLink id="e547-6c73-46ac-3bb5" name="Seeker" hidden="false" targetId="057e-0ae4-283d-49f7" type="profile"/>
         <infoLink id="4e37-13f9-95a1-787e" name="Targeter (Charge)" hidden="false" targetId="1891-8584-c483-7085" type="rule"/>
+        <infoLink id="7145-fef8-b7b2-8a5a" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="50f6-3576-6e9f-53ed" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
@@ -613,6 +968,8 @@
       <infoLinks>
         <infoLink id="dac3-776f-1327-0d24" name="Assault Shield" hidden="false" targetId="dd1a-a06d-d223-1974" type="profile"/>
         <infoLink id="f3df-ac9f-d83f-2598" name="Shield" hidden="false" targetId="ced4-3c62-3606-31ca" type="rule"/>
+        <infoLink id="7e91-cc64-316b-0ce2" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="54f4-4a4d-de25-93b4" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
@@ -622,6 +979,9 @@
       <infoLinks>
         <infoLink id="76e7-cf63-e1ad-d293" name="Power Attack (Spike)" hidden="false" targetId="f45d-f7bc-3379-d648" type="rule"/>
         <infoLink id="07e2-0aa9-fc0f-f6a4" name="Heavy Fusion Glaive" hidden="false" targetId="8dcb-ab78-c63a-4774" type="profile"/>
+        <infoLink id="fbe9-9a6e-5568-9b27" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="ac65-d14f-f5d4-2c06" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="57aa-ff0c-20d7-8086" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
@@ -632,6 +992,8 @@
         <infoLink id="01a2-65e6-1d2e-cc82" name="Maelstrom" hidden="false" targetId="25a1-6d64-56c1-aacb" type="profile"/>
         <infoLink id="a3d0-ef6c-bd14-1514" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
         <infoLink id="1704-0f12-1cb0-70d2" name="Spray Weapon" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+        <infoLink id="fab5-0c58-b19d-ff26" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="4cfd-75bc-768e-703c" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
@@ -641,6 +1003,8 @@
       <infoLinks>
         <infoLink id="6cd6-e5e1-4d3f-f431" name="Immolator" hidden="false" targetId="7c53-c70a-1c43-026e" type="profile"/>
         <infoLink id="792c-66ae-1b8f-c32d" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+        <infoLink id="6042-f394-b694-d1f3" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+        <infoLink id="610b-ac65-7f49-fba5" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
@@ -650,15 +1014,25 @@
       <infoLinks>
         <infoLink id="0893-95ef-17f6-9577" name="Sun Piercer" hidden="false" targetId="7072-d46a-3c10-146e" type="profile"/>
         <infoLink id="8b61-3b82-9641-4714" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+        <infoLink id="d14e-0a7a-280d-5768" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+        <infoLink id="80f8-3f88-cbce-9893" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37f3-9d01-47ec-d8b5" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <infoGroups>
+        <infoGroup id="490b-4580-a123-7675" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="aa0e-e35c-ff1d-5456" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="9123-967a-98ab-d0e2" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
       <infoLinks>
         <infoLink id="2a37-da8a-33ec-3d1d" name="Grenade Launcher" hidden="false" targetId="ef30-bca6-f0f8-e006" type="profile"/>
-        <infoLink id="6499-a1c1-b12d-1b01" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="6499-a1c1-b12d-1b01" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
@@ -668,200 +1042,385 @@
       <infoLinks>
         <infoLink id="1f67-89e2-4e02-7ba3" name="Force Hammer" hidden="false" targetId="9081-2e7b-50a4-a7bf" type="profile"/>
         <infoLink id="568b-2b8d-a74b-8695" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+        <infoLink id="7d9f-781f-1af2-cb7b" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="de4e-1c13-04aa-87da" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="25ba-40b2-f2fa-159f" name="Castigator Missiles" hidden="false" collective="false" import="true" type="upgrade">
+      <infoGroups>
+        <infoGroup id="2af2-3dc7-86a6-dfa4" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="3274-5255-edd9-347c" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="947e-3d57-60fc-981f" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="3ee3-1510-237a-2aea" name="Castigator Missiles" hidden="false" targetId="0fbe-992f-cc4a-76e4" type="profile"/>
+        <infoLink id="50ca-49ec-e0ca-ab07" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="52e8-b456-616e-1db5" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8019-d27d-6a60-e3b0" name="Radliffe X9" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="1a46-bbe3-f7bd-1eff" name="Radliffe X9" hidden="false" targetId="24ae-4ea4-01f5-7065" type="profile"/>
+        <infoLink id="f3d4-3f50-6864-03a1" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="f5f1-65d4-44a3-ee1e" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="faaa-ac60-3f57-74db" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="30a2-1923-ff65-6b4e" name="Harbinger Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="70dd-fb78-4d2c-4ea6" name="Harbinger Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1848-772f-5be8-4d58" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="1dd2-0e69-2477-2fda" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="4783-2b3e-f394-a6eb" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8600-d8ad-0383-4869" name="Arc Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="51fd-297d-eca2-934d" name="Arc Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="77bc-aed8-5fa4-eef1" name="Armor-Piercing" hidden="false" targetId="4a62-dd5f-b896-d12c" type="rule"/>
+        <infoLink id="c6e9-1426-964c-cd11" name="Malefactor" hidden="false" targetId="cbff-67cf-93ba-4651" type="rule"/>
+        <infoLink id="38b1-9001-47bd-5875" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+        <infoLink id="e54e-83ca-c98e-2766" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="ad7e-4607-ac76-9981" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aadd-fa45-1db9-5327" name="Bayonet" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="cc68-46c7-0b8f-9d7b" name="Bayonet" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b7fd-ad15-bfee-6b54" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="29c4-6788-7b72-c41b" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17f0-dd6f-101f-40a4" name="Fusion Spear" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8052-ee88-0a95-8d40" name="Fusion Spear" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a467-f137-a349-1941" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="e456-c2bf-16d8-8c53" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1464-f795-756d-1758" name="Force Generator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4d67-c877-64be-74e3" name="Force Generator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d2b0-e67a-1463-8145" name="Force Ram (Spike)" hidden="false" targetId="c2f8-48d9-d6ed-1bdf" type="rule"/>
+        <infoLink id="a9e5-076e-689d-8f32" name="Lock Down" hidden="false" targetId="c5f2-b7a9-63fd-e500" type="rule"/>
+        <infoLink id="2a91-253e-1dc0-0a49" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="a515-a0c3-60d3-5e4a" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2335-aa3e-baca-5120" name="Handgun" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b4ea-7e98-1ebf-55f0" name="Handgun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="98f4-b976-c0b0-3517" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="deee-9d10-6967-6ded" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c703-3325-4b91-fb46" name="Null Hammer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2156-ee8a-8e93-f336" name="Null Hammer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="73fa-98ff-dac2-60bd" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="aee5-786b-344c-ad26" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="324f-7e5b-bd5e-2f1c" name="Null Strike" hidden="false" targetId="f174-cd6d-3802-1cbc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c688-ecde-1912-57bb" name="Pulse Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="df8b-7bc0-016d-fb1f" name="Pulse Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fdda-5058-56f0-a2a3" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="45cd-5939-f203-0dc0" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="48df-2d6f-3fde-5aef" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+        <infoLink id="aee3-b46d-3c44-4938" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7e79-412e-c223-d0a2" name="Fixed Guns" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="292b-0bf6-015d-1b44" name="Fixed Guns" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fb1d-b26f-9760-6640" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="8e1b-00e2-c1c4-e12f" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ae2e-1ebb-80ce-24ed" name="Force Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="06ff-4d1c-083d-73bf" name="Force Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c12c-1ff3-d8eb-ac21" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+        <infoLink id="a9bb-f7ce-85c5-e4a9" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="cf92-3465-b191-dd7a" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf92-181b-8809-789e" name="Tempest Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b806-6a19-f333-6707" name="Tempest Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a647-d8f3-9bb9-1187" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="7f02-1b76-3e56-74ed" name="Spray Weapon" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+        <infoLink id="b184-6cb4-db44-caee" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+        <infoLink id="61db-6265-0588-d4da" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="924c-5fcf-2a4f-e516" name="Evasion Drive (Charge)" hidden="false">
+      <description>When this model is missed by an attack while charged, immediately after the attack is resolved it can move up to 3&quot;.</description>
+    </rule>
+    <rule id="333f-86b4-6f91-3619" name="High Performance (Spike)" hidden="false"/>
+    <rule id="8cd5-24b7-348a-7b0e" name="Full Burn" hidden="false">
+      <description>This vehicle can move up to 5&quot; at the end of it&apos;s activation, then this maneuver expires.</description>
+    </rule>
+    <rule id="ffb3-1376-f6a4-e56b" name="Sky Hunter" hidden="false">
+      <description>This model can reroll it&apos;s ranged attack rolls. A roll can be rerolled once as a result of Sky Hunter. This maneuver expires at the end of this activation.</description>
+    </rule>
+  </sharedRules>
   <sharedProfiles>
     <profile id="a669-670b-4692-9886" name="Assault Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
       </characteristics>
     </profile>
     <profile id="d5e7-173e-2edd-379f" name="Bayonet" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
       </characteristics>
     </profile>
     <profile id="c07f-caf7-6a51-a23e" name="Fusion Glaive" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Power Attack (Spike)</characteristic>
       </characteristics>
     </profile>
     <profile id="34fc-3815-d467-5147" name="Harbinger Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Hunter-Killer Rounds (Spike), Strafe</characteristic>
       </characteristics>
     </profile>
     <profile id="060f-6de4-deeb-6f29" name="Null Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Null Strike</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ec42-ff05-a4f4-2c0a" name="Repulsor Shield" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Repulsor Ram (Spike), Shield</characteristic>
       </characteristics>
     </profile>
     <profile id="da37-9cac-c150-96b5" name="Fusion Sword" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
       </characteristics>
     </profile>
     <profile id="9828-e26b-6ead-00a8" name="Pulse Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Explosion and Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Blast Weapon</characteristic>
       </characteristics>
     </profile>
     <profile id="fa30-c94b-dcf7-e67e" name="Handgun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
       </characteristics>
     </profile>
     <profile id="b8e5-a35e-a3f3-26c5" name="Null Hammer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Null Strike</characteristic>
       </characteristics>
     </profile>
     <profile id="dd1a-a06d-d223-1974" name="Assault Shield" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Shield</characteristic>
       </characteristics>
     </profile>
     <profile id="8dcb-ab78-c63a-4774" name="Heavy Fusion Glaive" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">6</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Power Attack (Spike)</characteristic>
       </characteristics>
     </profile>
     <profile id="057e-0ae4-283d-49f7" name="Seeker" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Targeter (Charge)</characteristic>
       </characteristics>
     </profile>
     <profile id="07a0-694d-2123-77ca" name="Starburst Missiles" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic and Explosive</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Targeter (Charge)</characteristic>
       </characteristics>
     </profile>
     <profile id="45f8-4b97-fbe2-b4f7" name="Force Generator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Force Ram (Spike), Lock Down</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a3fe-e59d-e3af-c0fd" name="Arc Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Attack Mode (Arc Blade)</characteristic>
       </characteristics>
     </profile>
     <profile id="9081-2e7b-50a4-a7bf" name="Force Hammer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Repulsor</characteristic>
       </characteristics>
     </profile>
     <profile id="ef30-bca6-f0f8-e006" name="Grenade Launcher" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic and Explosion</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Blast Weapon</characteristic>
       </characteristics>
     </profile>
     <profile id="7072-d46a-3c10-146e" name="Sun Piercer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">High Intensity (Charge)</characteristic>
       </characteristics>
     </profile>
     <profile id="7c53-c70a-1c43-026e" name="Immolator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">16</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Fire</characteristic>
       </characteristics>
     </profile>
     <profile id="25a1-6d64-56c1-aacb" name="Maelstrom" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
       <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
         <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
         <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Defense Matrix (Charge), Spray</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="12c2-55fa-f2ae-4217" name="Fusion Spear" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+      <characteristics>
+        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0fbe-992f-cc4a-76e4" name="Castigator Missiles" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+      <characteristics>
+        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="24ae-4ea4-01f5-7065" name="Radliffe X9" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+      <characteristics>
+        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Marcher_Worlds.cat
+++ b/Marcher_Worlds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="154e-fbe3-f081-b409" name="Marcher Worlds" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="154e-fbe3-f081-b409" name="Marcher Worlds" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="6e64-0ab9-a430-a976" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="c9ff-4d93-b27c-d56b" name="Dusk Wolf" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -34,9 +34,11 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="e48f-6463-ae52-a70b" name="Neural Net Cortex" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="3bcc-c8c5-da55-d10a" name="Neural Net" hidden="false" targetId="18a0-5c55-a14a-519d" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="b2a4-c593-4877-2d15" name="Neural Net" hidden="false">
+                  <description>This model gains a cumulative +1 DEF bonus for each other friendly unit within 5&quot; , up to a bonus of +3.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -51,9 +53,11 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="fe55-8c8f-6470-84ca" name="Fighter Cortex" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="3025-c84f-b19d-b0b9" name="Rapid Strike" hidden="false" targetId="5e13-0046-6809-c381" type="rule"/>
-              </infoLinks>
+              <rules>
+                <rule id="ca38-4576-6d30-be6a" name="Rapid Strike" hidden="false">
+                  <description>When this model attacks during its activation, it can make one additional melee atack with each of its melee weapons.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -78,25 +82,36 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a1b-040b-243e-5ae2" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="ce28-4860-ec87-f510" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry"/>
-                <entryLink id="65e7-4ffd-24f7-59b4" name="Ripper" hidden="false" collective="false" import="true" targetId="dcba-bdcf-28df-5b87" type="selectionEntry"/>
-                <entryLink id="22c8-f9e9-5cde-03c2" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry"/>
-                <entryLink id="147d-5ab2-aee4-1953" name="Impaler" hidden="false" collective="false" import="true" targetId="3807-0a5f-9501-0ed2" type="selectionEntry"/>
-                <entryLink id="3b7c-f31e-7738-a137" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry"/>
-                <entryLink id="d9e4-1206-e235-4b6c" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry"/>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="854f-11f5-dfc4-b4e3" name="Right Arm" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7867-df3f-9aef-465b" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="ff92-cdcf-17a0-cbad" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry"/>
-                <entryLink id="5026-323f-1c95-e8b3" name="Ripper" hidden="false" collective="false" import="true" targetId="dcba-bdcf-28df-5b87" type="selectionEntry"/>
-                <entryLink id="a239-56e4-0b9d-fd47" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry"/>
-                <entryLink id="8229-5f0b-d86f-874b" name="Impaler" hidden="false" collective="false" import="true" targetId="3807-0a5f-9501-0ed2" type="selectionEntry"/>
-                <entryLink id="44c9-0768-6ceb-e1b6" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry"/>
-                <entryLink id="a006-3648-9ab1-7783" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry"/>
+                <entryLink id="ce28-4860-ec87-f510" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="65e7-4ffd-24f7-59b4" name="Ripper" hidden="false" collective="false" import="true" targetId="dcba-bdcf-28df-5b87" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="22c8-f9e9-5cde-03c2" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="147d-5ab2-aee4-1953" name="Impaler" hidden="false" collective="false" import="true" targetId="3807-0a5f-9501-0ed2" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3b7c-f31e-7738-a137" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d9e4-1206-e235-4b6c" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="2de8-2fc1-4452-4a71" name="Shoulder" hidden="false" collective="false" import="true">
@@ -104,10 +119,63 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2169-6ca5-d542-84b4" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="8823-6652-fe9e-c3a1" name="Talon Rocket Pod" hidden="false" collective="false" import="true" targetId="c24f-faf3-2890-4e6e" type="selectionEntry"/>
-                <entryLink id="f116-b857-30f1-c521" name="Rail Gun" hidden="false" collective="false" import="true" targetId="921a-71ea-73af-991d" type="selectionEntry"/>
-                <entryLink id="5486-4a9f-8747-1b6c" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry"/>
-                <entryLink id="4332-8710-0848-cfbe" name="Wildflower" hidden="false" collective="false" import="true" targetId="28df-111d-3305-ece5" type="selectionEntry"/>
+                <entryLink id="8823-6652-fe9e-c3a1" name="Talon Rocket Pod" hidden="false" collective="false" import="true" targetId="c24f-faf3-2890-4e6e" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f116-b857-30f1-c521" name="Rail Gun" hidden="false" collective="false" import="true" targetId="921a-71ea-73af-991d" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5486-4a9f-8747-1b6c" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4332-8710-0848-cfbe" name="Wildflower" hidden="false" collective="false" import="true" targetId="28df-111d-3305-ece5" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d392-f9ca-2982-3428" name="Right Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f84-43c4-8241-d9e6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7cd8-0c04-8186-86eb" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a0f3-13fd-9a2b-89ea" name="Ripper" hidden="false" collective="false" import="true" targetId="dcba-bdcf-28df-5b87" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ff85-b20a-916b-0e95" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="caf6-44c1-a78e-f2ae" name="Impaler" hidden="false" collective="false" import="true" targetId="3807-0a5f-9501-0ed2" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9890-4d0a-b28c-1261" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0f70-03fb-ae4c-da82" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -136,15 +204,30 @@
       </profiles>
       <infoLinks>
         <infoLink id="8a42-ef3f-481b-4dcd" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
-        <infoLink id="ccde-a0da-2252-b483" name="Battle Rifle" hidden="false" targetId="0ee5-8bc2-a046-94ba" type="profile"/>
-        <infoLink id="97d0-fb79-03c0-b4b7" name="Fusion Blade" hidden="false" targetId="a7eb-f0e9-f06e-de5d" type="profile"/>
-        <infoLink id="8788-c3be-06d2-471d" name="Null Detonator" hidden="false" targetId="c08c-1fef-6c35-56f9" type="profile"/>
-        <infoLink id="f7b0-40df-7d70-d367" name="Mechanikal Optics (Charge)" hidden="true" targetId="5c5b-ce9c-65e9-1bb6" type="rule"/>
-        <infoLink id="076d-5e94-3589-2bc6" name="Nullifier" hidden="true" targetId="24ab-84f6-b1d5-3fba" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4b09-b7b3-0c6e-77df" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="8045-c65d-5323-64a7" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4722-c246-5d2d-1526" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6895-5904-6ea1-70c9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6e26-cab8-ccdf-ce68" name="Null Detonator" hidden="false" collective="false" import="true" targetId="b93c-4a3a-7273-5ec8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="807d-b6d8-1a57-68db" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b924-fa90-b10b-09b2" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b10b-5310-ec50-c766" name="Fusion Blade" hidden="false" collective="false" import="true" targetId="ddfc-dacc-8d2e-265f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2a9-ddf5-b01c-83d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b45-edcf-e51f-69b9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -167,23 +250,50 @@
           </characteristics>
         </profile>
       </profiles>
-      <infoGroups>
-        <infoGroup id="00c5-9737-bba6-c349" name="Weapon Rules" hidden="false">
-          <infoLinks>
-            <infoLink id="8a4d-42d0-ac3c-7f99" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
-          </infoLinks>
-        </infoGroup>
-      </infoGroups>
+      <rules>
+        <rule id="12c1-a47d-e3c5-98ec" name="Fury Reciprocator (Spike)" hidden="false">
+          <description>When you channel a Fury Cypher through this model, after the attack is resolved, this model can spike to return the Cypher card to your hand.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="5ea1-7e83-f09c-30a0" name="Arcantrik Amplifier (Charge)" hidden="false" targetId="a4ab-9b99-4e38-42f9" type="rule"/>
         <infoLink id="418f-4175-b444-acca" name="Arc Relay (10)" hidden="false" targetId="d687-ce36-bcf1-95c6" type="rule"/>
-        <infoLink id="a35f-628f-3ea5-4c8d" name="Fury Reciprocator (Spike)" hidden="false" targetId="403b-2f51-d670-cb59" type="rule"/>
-        <infoLink id="cea1-5e9b-e9a6-9297" name="Handgun" hidden="false" targetId="f54d-f3a0-98f9-4a16" type="profile"/>
-        <infoLink id="2fc3-69c9-86de-bbc7" name="Battle Staff" hidden="false" targetId="bb53-9901-54b9-acb5" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a625-6f06-b778-1be7" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="22b3-253f-de11-b472" name="Battle Staff" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9037-25ad-8fe0-48cf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="806c-8552-f3c5-ced6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="59f5-30ba-fbb3-d39f" name="Battle Staff" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="db2d-d70e-bf43-86c9" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="0599-5929-287b-f1fe" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+            <infoLink id="d950-2e59-1826-54db" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0360-9704-56bd-db21" name="Handgun" hidden="false" collective="false" import="true" targetId="4466-6c6e-5b1e-2620" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d885-31fd-921e-43fc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d070-4979-2ca7-741c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -207,15 +317,44 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="290f-9746-50c5-2e33" name="Combat Blade" hidden="false" targetId="da9e-e7f3-bd55-b883" type="profile"/>
         <infoLink id="0b09-a1eb-f310-7dd5" name="Fire &amp; Displace" hidden="false" targetId="7e28-2524-d7db-abda" type="rule"/>
         <infoLink id="4c00-57ec-47ad-9c1c" name="Mimetic Cloak (Charge)" hidden="false" targetId="7adb-f157-4c5d-c8a9" type="rule"/>
-        <infoLink id="027e-9a4a-651f-03a8" name="Sniper Rifle" hidden="false" targetId="b4dc-c2f5-7af3-717f" type="profile"/>
-        <infoLink id="50d1-05d7-577d-e824" name="Arc Booster (Spike)" hidden="false" targetId="4b13-2e42-d9c4-4f2f" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="23fe-3154-7bac-f47b" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2985-589d-685d-6441" name="Sniper Rifle" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50a-503b-fdad-15e7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb3c-c868-9827-e08d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9d25-5ffd-d6d8-713e" name="Sniper Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">15</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e07a-5349-a343-f525" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="8fe4-9a76-6e39-2926" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="dc89-f9cb-73bb-4b31" name="Arc Booster (Spike)" hidden="false" targetId="a339-fbad-c256-4d89" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="212f-496a-0ab0-9853" name="Combat Blade" hidden="false" collective="false" import="true" targetId="bad8-a8e3-7f74-4585" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db97-8c11-b9a8-ec5a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fff9-ae13-d117-24a2" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -239,14 +378,59 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f0e1-f17b-55e3-86ff" name="Fusion Torch" hidden="false" targetId="ab3d-c807-a789-e8cc" type="profile"/>
-        <infoLink id="e2e5-45e1-a5d5-0f6c" name="Wrench" hidden="false" targetId="cb9e-0215-1cf9-2dc5" type="profile"/>
         <infoLink id="72a2-dcab-75e7-045f" name="Jump Start (Spike)" hidden="false" targetId="058b-f612-39f3-2bd6" type="rule"/>
         <infoLink id="4e18-6d46-2136-d986" name="Repair (Action)" hidden="false" targetId="4339-3e50-7d6c-5e50" type="rule"/>
         <infoLink id="9755-c457-568c-2ac9" name="Spotlight (Charge)" hidden="false" targetId="7f04-3809-34a7-682d" type="rule"/>
         <infoLink id="27b3-c2a9-9a2b-9221" name="Tune Up (Action)" hidden="false" targetId="351f-1213-6042-662b" type="rule"/>
-        <infoLink id="81b3-210e-db5a-086c" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="327d-45b0-6705-20c3" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="45a4-3e0b-60eb-ed38" name="Fusion Torch" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bcd-9c17-20ae-a45f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d24-a9da-59eb-14b8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="81dd-8d1b-d357-1975" name="Fusion Torch" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="2bdd-e673-fcb9-79c8" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="b3ab-26a4-ff4a-a388" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+            <infoLink id="7988-f47f-be5c-1b8b" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="385f-0594-880a-780d" name="Wrench" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66c6-e6bc-ff2b-c92c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a319-71a1-83b7-2094" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7fed-71d0-afaf-f4fa" name="Wrench" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="dd5e-67a1-b167-975e" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="727d-a84f-903a-1227" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -269,10 +453,14 @@
           </characteristics>
         </profile>
       </profiles>
-      <infoLinks>
-        <infoLink id="583a-c838-e0e6-663c" name="Jump Jets (Spike)" hidden="false" targetId="3189-813b-6b69-49ec" type="rule"/>
-        <infoLink id="767b-d664-f5f7-3475" name="Thrusters (Charge)" hidden="false" targetId="1dbf-ada7-71d2-6c11" type="rule"/>
-      </infoLinks>
+      <rules>
+        <rule id="3558-9a05-9181-2122" name="Jump Jets (Spike)" hidden="false">
+          <description>Once per activation, this model can spike to gain +3 SPC and Flight until the end of its activation.</description>
+        </rule>
+        <rule id="3854-fe4c-2f9f-2e55" name="Thrusters (Charge)" hidden="false">
+          <description>While charged, this model ignores movement penalties for rough terrain. Additionally, for each Arc this model is charged with, it gains +1 DEF.</description>
+        </rule>
+      </rules>
       <categoryLinks>
         <categoryLink id="a300-0578-44c2-242d" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
@@ -292,9 +480,29 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="df2a-b5e9-1f91-73df" name="Bomber Cortex" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="8100-5f04-33c9-495f" name="Bomber" hidden="false">
+                  <description>This model gains +1 action die on attack rolls with explosion weapons. Additionally, when this model makes an attack with an explosion weapon while it has Flight, immediately after the attack is resolved, this model can move up to 2&quot;.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2c34-bb1d-f0f4-fcab" name="Dog Fighter" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="6a9c-937e-831c-3a46" name="Bomber" hidden="false" targetId="8d84-efa6-1ae3-a78b" type="rule"/>
+                <infoLink id="826a-bffb-93af-deef" name="Slip Field (Charge)" hidden="false" targetId="77c5-00b4-a116-e328" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4fc-acf3-e86d-35ee" name="Precision" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="47df-4783-cc22-7471" name="Structural Analyzer" hidden="false">
+                  <description>This unit&apos;s melee weapons gain +1 POW.</description>
+                </rule>
+              </rules>
               <costs>
                 <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
               </costs>
@@ -326,24 +534,17 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="6f5f-d09f-3fc7-f0a8" name="Right Arm" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbf9-84e9-a152-00c4" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="b764-73bc-89b2-2a94" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry">
-                  <costs>
-                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6cb5-f44b-a4e7-7df7" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry">
+                <entryLink id="713d-7b69-fdb4-5712" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="303a-21ff-cdc4-dc56" name="Fusion Drill" hidden="false" collective="false" import="true" targetId="3cc2-32aa-c726-779a" type="selectionEntry">
+                <entryLink id="11b8-b6c5-6fbb-0604" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bbd3-2fcc-2910-c8c0" name="Rock Buster" hidden="false" collective="false" import="true" targetId="a69e-85de-6f7e-c93a" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
                   </costs>
@@ -370,26 +571,101 @@
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="e439-c270-24cc-55d0" name="Right Shoulder" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da8-4bca-fb72-a914" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="94d0-5e38-e15f-5ad0" name="Talon Rocket Pod" hidden="false" collective="false" import="true" targetId="c24f-faf3-2890-4e6e" type="selectionEntry">
+                <entryLink id="e212-32c6-5583-bcfd" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6712-e3b7-54ac-b26a" name="Cyclone Cannon" hidden="false" collective="false" import="true" targetId="1370-1442-954f-4994" type="selectionEntry">
+                  <infoLinks>
+                    <infoLink id="ae48-7f79-c925-c470" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
+                    <infoLink id="0407-d338-1944-e7c1" name="Anti-Air" hidden="false" targetId="8758-53ba-60e8-19ab" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1a0c-97b1-d1da-ea2f" name="Vortex Missile" hidden="false" collective="false" import="true" targetId="177d-e828-357a-dec8" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="4ae7-475a-e3fb-9de4" name="Rail Gun" hidden="false" collective="false" import="true" targetId="921a-71ea-73af-991d" type="selectionEntry">
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2b0e-0b63-0a58-83c2" name="Right Arm" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1374-4fde-2e0d-4399" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="96f7-2d6e-4b61-8d9b" name="Battle Rifle" hidden="false" collective="false" import="true" targetId="3b72-5fc5-a159-1429" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9dab-62c2-effd-aac6" name="Flame Thrower" hidden="false" collective="false" import="true" targetId="3eb8-20ba-d492-11b0" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1487-5f9a-0af2-2d72" name="Fusion Drill" hidden="false" collective="false" import="true" targetId="3cc2-32aa-c726-779a" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="56e3-6632-6ae0-d6e1" name="Particle Accelerator" hidden="false" collective="false" import="true" targetId="6485-7691-7900-71d5" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="59e9-71da-a464-84dc" name="Slug Gun" hidden="false" collective="false" import="true" targetId="e9bf-7176-b61d-4e73" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cbf3-e086-cb1c-5b9a" name="Rock Buster" hidden="false" collective="false" import="true" targetId="a69e-85de-6f7e-c93a" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="5411-0e3b-00cc-d3de" name="Right Shoulder" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c1-3d74-db10-81e9" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0aa4-2ba5-18c6-b74f" name="Talon Rocket Pod" hidden="false" collective="false" import="true" targetId="c24f-faf3-2890-4e6e" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f5d3-c915-37d8-bff2" name="Rail Gun" hidden="false" collective="false" import="true" targetId="921a-71ea-73af-991d" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="e2da-22f0-e70d-6a5b" name="Particle Cannon" hidden="false" collective="false" import="true" targetId="4815-be73-0ecc-2255" type="selectionEntry">
+                <entryLink id="8c28-eab5-58f4-e72c" name="Particle Cannon" hidden="false" collective="false" import="true" targetId="4815-be73-0ecc-2255" type="selectionEntry">
                   <costs>
                     <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4f12-a0d9-3a8c-1755" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ed30-3c77-d09f-4478" name="Cyclone Cannon" hidden="false" collective="false" import="true" targetId="1370-1442-954f-4994" type="selectionEntry">
+                  <infoLinks>
+                    <infoLink id="36a3-8101-38ba-5b7e" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
+                    <infoLink id="48df-6907-e43e-bec1" name="Anti-Air" hidden="false" targetId="8758-53ba-60e8-19ab" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4fe0-96f2-c5f6-a3cd" name="Vortex Missile" hidden="false" collective="false" import="true" targetId="177d-e828-357a-dec8" type="selectionEntry">
+                  <costs>
+                    <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -420,14 +696,38 @@
       </profiles>
       <infoLinks>
         <infoLink id="589e-1c97-ce19-9e2b" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
-        <infoLink id="21b9-b42f-bb36-5e60" name="Talon Rocket Launcher" hidden="false" targetId="c2ec-3d61-5328-0177" type="profile"/>
-        <infoLink id="b5e7-9d50-92cb-ac2f" name="Fusion Blade" hidden="false" targetId="a7eb-f0e9-f06e-de5d" type="profile"/>
-        <infoLink id="0f1c-8161-1d44-40f9" name="Blast Weapon" hidden="true" targetId="4478-b4bd-42be-09e2" type="rule"/>
-        <infoLink id="1517-0403-5b53-cff5" name="Targeter (Charge)" hidden="true" targetId="1891-8584-c483-7085" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dfd4-e405-e1d1-38d7" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7623-6841-38fc-3cf1" name="Talon Rocket Launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca6f-1517-19c4-0c7e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b61b-1b08-1874-a275" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="be83-e3b9-ab31-49be" name="Talon Rocket Launcher" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="9e02-8b77-4b20-074f" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="8a60-9b8a-1d97-26e2" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="b560-802e-8754-8897" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+            <infoLink id="791b-0095-5095-1812" name="Targeter (Charge)" hidden="false" targetId="1891-8584-c483-7085" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0c54-b86e-00cb-2841" name="Fusion Blade" hidden="false" collective="false" import="true" targetId="ddfc-dacc-8d2e-265f" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -451,16 +751,359 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="7fb3-ce7f-6a52-f494" name="Arclock Pistol" hidden="false" targetId="1ad5-cbfa-6279-0f86" type="profile"/>
-        <infoLink id="91da-b9e5-46ba-490f" name="Arclock Pistol" hidden="false" targetId="1ad5-cbfa-6279-0f86" type="profile"/>
-        <infoLink id="1830-f539-c121-fde7" name="Maelstrom Activator (Spike)" hidden="false" targetId="4c2b-8ff6-dbbb-8525" type="rule"/>
+        <infoLink id="1830-f539-c121-fde7" name="Maelstrom Activator (Spike)" hidden="false" targetId="51e5-2ce6-9605-ac40" type="rule"/>
         <infoLink id="1520-b324-783f-6ae1" name="Smart Lock (Charge)" hidden="false" targetId="6e59-f079-4476-730f" type="rule"/>
         <infoLink id="1e88-5db1-781a-2235" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
-        <infoLink id="71d9-dbce-1c6f-7602" name="Attack Mode (Arclock Pistol)" hidden="false" targetId="468a-cdd0-c1f0-4d47" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="80d5-947e-7bb6-28da" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="721a-3a84-1c05-9d64" name="Arclock Pistol" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da17-c3c6-fd09-e81e" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b14-17aa-814e-dfbf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0a19-d0e7-b12f-a941" name="Arclock Pistol" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoGroups>
+            <infoGroup id="9728-f896-6ad5-73a3" name="Attack Mode" hidden="false">
+              <infoLinks>
+                <infoLink id="be94-90a8-91aa-3b4a" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+                <infoLink id="81c4-b3fb-c341-d938" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
+                <infoLink id="91f2-bba3-0345-dbdd" name="Revelator" hidden="false" targetId="c8f4-25c2-f013-c8b2" type="rule"/>
+              </infoLinks>
+            </infoGroup>
+          </infoGroups>
+          <infoLinks>
+            <infoLink id="b959-df4a-fa86-cfe8" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="e1ef-bcda-93a7-c980" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7dae-96da-d042-36b1" name="Ranger Infiltrators" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="5807-b968-dcb2-fcd6" name="Ranger Infiltrators" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">6</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">4</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">3</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">3</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="407f-f29d-909b-9e53" name="Dynamic Accelerator (Charge)" hidden="false" targetId="592d-4c1c-98fb-122f" type="rule"/>
+        <infoLink id="dd94-7d0a-71aa-004a" name="Slip Displacer (Spike)" hidden="false" targetId="6fe1-a603-4323-af51" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cc34-01c2-9d8a-a019" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="49d5-900a-0f88-c911" name="Fusion Axe" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="a730-6931-af3f-de4a" name="Fusion Axe" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="5114-0a1a-11ea-a8e9" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="28dc-44d2-4120-12e4" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+            <infoLink id="f656-61db-ef51-1fdb" name="Cleave" hidden="false" targetId="1a75-dcac-9578-c7f9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="99f6-f02b-49ac-e175" name="Magnetic Charge" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="b105-6158-494c-6557" name="Magnetic Charge" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="35f1-84f1-587b-d6a7" name="Delayed Blast" hidden="false">
+              <description>When this model hits with an attack with this weapon, before damage is rolled, this model can immediately move up to 3£. Additionally, when resolving an attack with this weapon, ignore this model when determining the two closest models to the target.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="ba0f-8a26-8841-9f1e" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="4b49-a622-7c21-85ae" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac68-7485-5e6f-56cf" name="Warder" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="increment" field="5474-2b1d-9949-72f8" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dae-96da-d042-36b1" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64e2-a6b6-1c07-bb9b" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3714-c286-79ac-2dcb" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5474-2b1d-9949-72f8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d6d3-3134-7217-bd04" name="Warder" hidden="false" typeId="ee5b-45d6-6439-5c83" typeName="Squad">
+          <characteristics>
+            <characteristic name="SPD" typeId="63e0-b44a-50f3-5d3f">*</characteristic>
+            <characteristic name="MAT" typeId="0a8b-a206-4acf-92ae">3</characteristic>
+            <characteristic name="RAT" typeId="d86f-3c79-7c50-0502">3</characteristic>
+            <characteristic name="DEF" typeId="d2bf-4ab1-bbd1-c53d">3</characteristic>
+            <characteristic name="ARM" typeId="df58-c0c5-6903-dd53">3</characteristic>
+            <characteristic name="NUM" typeId="cc5f-a02a-8153-9031">1</characteristic>
+            <characteristic name="CST" typeId="403d-0963-ce1f-565d">+1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6a67-71d4-e6e1-4564" name="Aporopaic Reactor (Spike)" hidden="false">
+          <description>When an enemy attack or special rule would cause a Cypher on this squad to expire, this model can spike to keep the Cypher from expiring.</description>
+        </rule>
+        <rule id="dc47-aa89-9345-0a0a" name="Arc Distuptor (Charge)" hidden="false">
+          <description>While this model is charged, models in the unit add two POWER dice to defense rolls against Fury attacks.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="dc45-df57-ee84-b0ee" name="Arc Exchange" hidden="false" targetId="089a-a7eb-cae0-9775" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f57d-9b13-a761-123a" name="New CategoryLink" hidden="false" targetId="fa79-7113-8f14-037f" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="eb4a-ca3f-4f53-dd12" name="Handgun" hidden="false" collective="false" import="true" targetId="4466-6c6e-5b1e-2620" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="059e-70e7-c658-2baf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04ef-9435-04ac-c8d9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1cd-771d-ad6a-f44b" name="Blast Shield" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce93-7578-ccd5-b328" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9840-2a29-a9b8-3877" name="Blast Shield" hidden="false" typeId="f21f-e3fc-861e-7041" typeName="Mantlet">
+          <characteristics>
+            <characteristic name="SPD" typeId="9a1a-1996-43a0-5ebf">-</characteristic>
+            <characteristic name="MAT" typeId="ef7d-7e69-bb45-465a">-</characteristic>
+            <characteristic name="RAT" typeId="0dee-6f34-8704-e237">-</characteristic>
+            <characteristic name="DEF" typeId="7629-6783-48fa-04fb">1</characteristic>
+            <characteristic name="ARM" typeId="8838-aacd-9ec7-99b1">4</characteristic>
+            <characteristic name="DMG" typeId="c150-c260-a91e-5bdb">2</characteristic>
+            <characteristic name="CST" typeId="e127-231f-27ff-e6a4">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b7e2-4a68-b13e-a7e6" name="Deployable Cover" hidden="false" targetId="7d92-ecde-abcd-cac0" type="rule"/>
+        <infoLink id="9359-3477-2120-2e3f" name="Compound Armor" hidden="false" targetId="17ec-c1b8-c3fb-459f" type="rule"/>
+        <infoLink id="ddb1-cd58-c116-3b13" name="Blast Shielding" hidden="false" targetId="4a41-827f-6868-3087" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="003f-77f1-0bb9-2172" name="New CategoryLink" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="true"/>
+        <categoryLink id="5418-51d2-091c-368e" name="New CategoryLink" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3132-1bd1-e790-5e29" name="Razorbat" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="6174-d9bd-e769-0a12" name="Razorbat" hidden="false" typeId="8503-75a8-8ab2-161b" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="SPD" typeId="d513-8b95-8e8b-9643">8</characteristic>
+            <characteristic name="MAT" typeId="dd71-a3b1-b5d2-4126">3</characteristic>
+            <characteristic name="RAT" typeId="4972-6b8a-4cc9-a39d">4</characteristic>
+            <characteristic name="DEF" typeId="5d4e-e604-9d25-f35d">3</characteristic>
+            <characteristic name="ARM" typeId="5dd6-51ae-08e3-2c18">5</characteristic>
+            <characteristic name="DMG" typeId="804d-3ef2-0e46-d938">4</characteristic>
+            <characteristic name="CST" typeId="c28f-24c8-5446-8b51">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="0944-8b52-c33e-a951" name="Maneuvers" hidden="false">
+          <infoLinks>
+            <infoLink id="22fe-57b8-eed1-35a3" name="Guns Ready" hidden="false" targetId="235c-e23b-4228-be38" type="rule"/>
+            <infoLink id="0213-d8d6-946f-6f35" name="Hit the Jump" hidden="false" targetId="dcdf-5590-dfa6-a721" type="rule"/>
+            <infoLink id="d534-89fe-a480-64fd" name="Stand and Deliver" hidden="false" targetId="6049-7ae2-4745-66d9" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="9b30-51fa-90a0-caa6" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
+        <infoLink id="2cac-b629-050e-2338" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
+        <infoLink id="60cd-fbcd-163d-0fcb" name="Maelstrom Activator (Spike)" hidden="false" targetId="51e5-2ce6-9605-ac40" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5b43-5bf2-5410-5616" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e882-0e8e-1656-3304" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="ecbb-d452-36d4-0214" scope="3132-1bd1-e790-5e29" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78e4-b3c6-f3a7-2d69" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e312-100c-fb4a-c7f7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fca9-7078-058b-5de4" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry">
+              <infoLinks>
+                <infoLink id="3b49-4537-4bec-9701" name="Turret" hidden="false" targetId="fdfc-0a81-546d-2c31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1ac1-3662-42c7-1c9d" name="Slug Cannon" hidden="false" collective="false" import="true" targetId="22e6-7312-979d-4404" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2b62-b39a-14cb-1934" name="Cyclone Cannon" hidden="false" collective="false" import="true" targetId="1370-1442-954f-4994" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f14-73d6-fa51-35e8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28c7-fd23-e024-030c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b722-8dc0-b3f3-4971" name="Fiddler &amp; Co" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="00d9-1bb1-1212-53f4" name="Fiddler &amp; Co" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">8</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">3</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">5</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">3</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">5</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">4</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="59b2-1750-de59-9a9b" name="Maneuvers" hidden="false">
+          <rules>
+            <rule id="7c21-2b91-b1a6-71a3" name="Playing Possum" hidden="false">
+              <description>The model gains Stealth while within rough or obscuring terrain. The maneuver expires at the beginning of this model&apos;s next activation.</description>
+            </rule>
+            <rule id="6f7b-628e-e994-8802" name="Shoot &amp; Scoot" hidden="false">
+              <description>Immediately after resolving a ranged attack made by this model, this model canmove up to 1&quot;. The maneuver expires at the end of this activation.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="8f1b-f0cf-2212-76e5" name="Guns Ready" hidden="false" targetId="235c-e23b-4228-be38" type="rule"/>
+            <infoLink id="2a6f-5d04-e736-5415" name="Hit the Jump" hidden="false" targetId="dcdf-5590-dfa6-a721" type="rule"/>
+            <infoLink id="a5f5-4754-c2dc-b214" name="Stand and Deliver" hidden="false" targetId="6049-7ae2-4745-66d9" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="a8e8-438f-9afb-73c7" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
+        <infoLink id="5683-0eb6-297a-d612" name="Defense Matrix (Charge)" hidden="false" targetId="834a-f198-e6c0-5923" type="rule"/>
+        <infoLink id="d282-7c51-cbb6-6468" name="Maelstrom Activator (Spike)" hidden="false" targetId="51e5-2ce6-9605-ac40" type="rule"/>
+        <infoLink id="8fd6-6478-5c27-5dee" name="Smart Lock (Charge)" hidden="false" targetId="6e59-f079-4476-730f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a135-ff57-19ca-5ba5" name="New CategoryLink" hidden="false" targetId="63b7-c3cd-7f99-1cf0" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c615-c8dc-5184-147c" name="Hardpoint" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="ecbb-d452-36d4-0214" scope="b722-8dc0-b3f3-4971" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a31-673e-c11a-81dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7e1-8589-5af3-5e6f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="41d7-5fe7-3459-fccf" name="Particle Blaster" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="83bb-7b57-df38-0409" name="Particle Blaster" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+                    <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="8427-fe77-9b71-1006" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+                <infoLink id="a91e-4b8c-a9ae-4a0f" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
+                <infoLink id="3688-9a23-2c1c-4f09" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+                <infoLink id="68dc-a631-c44c-ecba" name="Singularity Collapse" hidden="false" targetId="4bcb-c9b9-251a-f2a5" type="rule"/>
+                <infoLink id="a1c0-a9f5-8b8f-3778" name="Turret" hidden="false" targetId="fdfc-0a81-546d-2c31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="b368-374d-68e8-f384" name="Blazer" hidden="false" collective="false" import="true" targetId="92f0-ed13-0a2c-ecae" type="selectionEntry">
+              <infoLinks>
+                <infoLink id="048c-68d6-c84b-2d9e" name="Turret" hidden="false" targetId="fdfc-0a81-546d-2c31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="841b-116d-2aef-0367" name="Slug Cannon" hidden="false" collective="false" import="true" targetId="22e6-7312-979d-4404" type="selectionEntry">
+              <costs>
+                <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d573-409e-a69c-015e" name="Talon Mk II" hidden="false" collective="false" import="true" targetId="e185-7f38-64a3-5dfe" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9619-949b-eb10-ad6b" name="Cyclone Cannon" hidden="false" collective="false" import="true" targetId="1370-1442-954f-4994" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dee-fb44-11d3-4437" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a0a-ed6a-292f-98c6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -470,306 +1113,372 @@
     <entryLink id="9584-9d8c-4fe1-fded" name="Cyphers" hidden="false" collective="false" import="true" targetId="3961-255e-7446-6cc4" type="selectionEntry"/>
     <entryLink id="89cd-eb23-64dd-9494" name="Voitek Sudal, Bounty Hunter" hidden="false" collective="false" import="true" targetId="d57b-15ce-482f-c16c" type="selectionEntry"/>
     <entryLink id="0588-8127-196b-ea45" name="Captain Jax Redblade" hidden="false" collective="false" import="true" targetId="2409-20b7-fd32-ff5d" type="selectionEntry"/>
+    <entryLink id="0236-3eef-b411-1851" name="Corebus" hidden="false" collective="false" import="true" targetId="413f-3332-67a2-8853" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="3b72-5fc5-a159-1429" name="Battle Rifle" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7a52-be23-8755-ef48" name="Battle Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="d079-0341-9b8b-acc3" name="Battle Rifle" hidden="false" targetId="0ee5-8bc2-a046-94ba" type="profile"/>
-        <infoLink id="d6fb-0ff9-3a90-ad26" name="Mechanikal Optics (Charge)" hidden="false" targetId="5c5b-ce9c-65e9-1bb6" type="rule"/>
+        <infoLink id="5e05-47eb-211f-a699" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="46aa-5912-5f69-66e1" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="e34f-b029-926d-aae5" name="Mechanikal Optics (Charge)" hidden="false" targetId="7995-7ab0-c3da-f21e" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dcba-bdcf-28df-5b87" name="Ripper" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6d33-a177-508e-eb91" name="Ripper" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="cd90-8f74-1fb1-0d29" name="Ripper" hidden="false" targetId="b5f5-c5af-2b1d-db71" type="profile"/>
-        <infoLink id="20bb-3e59-6766-fc18" name="Cleave" hidden="false" targetId="9b60-e71e-a84d-0bd7" type="rule"/>
+        <infoLink id="3ae1-d5fb-2a9e-0872" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="93a6-937e-2bbf-e417" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="823a-82b5-acb2-e583" name="Cleave" hidden="false" targetId="1a75-dcac-9578-c7f9" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3eb8-20ba-d492-11b0" name="Flame Thrower" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3a69-5b4e-3508-99b8" name="Flame Thrower" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="5fd4-b3c7-df1f-ff1b" name="Flame Thrower" hidden="false" targetId="d62d-05b1-b29b-d144" type="profile"/>
         <infoLink id="e9eb-386d-868b-cda5" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
         <infoLink id="f7a0-b712-ab42-9b55" name="Spray Weapon" hidden="false" targetId="c56a-eb04-a80f-be7d" type="rule"/>
+        <infoLink id="b28b-8132-2eee-708b" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c24f-faf3-2890-4e6e" name="Talon Rocket Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="83db-55d9-330f-8246" name="Talon Rocket Pod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="82a7-77ed-342b-80a1" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="b6ea-8dd5-856b-10b8" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="cdfc-94e2-9f03-76c9" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
       <infoLinks>
-        <infoLink id="2655-f02c-4d9a-1690" name="Talon Rocket Pod" hidden="false" targetId="a099-d402-794a-98f5" type="profile"/>
-        <infoLink id="908e-7823-dc2e-b2e1" name="Blast Weapon" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="908e-7823-dc2e-b2e1" name="Blast" hidden="false" targetId="4478-b4bd-42be-09e2" type="rule"/>
+        <infoLink id="e191-ca2f-545c-966d" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="921a-71ea-73af-991d" name="Rail Gun" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8f5b-7877-c211-dd6c" name="Rail Gun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">18</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="397e-8330-a491-c30f" name="Rail Gun" hidden="false" targetId="9c57-7e77-2600-e924" type="profile"/>
-        <infoLink id="4004-a809-b015-3c59" name="Arc Booster (Spike)" hidden="false" targetId="4b13-2e42-d9c4-4f2f" type="rule"/>
+        <infoLink id="4004-a809-b015-3c59" name="Arc Booster (Spike)" hidden="false" targetId="a339-fbad-c256-4d89" type="rule"/>
+        <infoLink id="3335-4759-10c2-e2b2" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="6701-fe3e-1551-3e5d" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4815-be73-0ecc-2255" name="Particle Cannon" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="637e-6655-edb7-8221" name="Particle Cannon" hidden="false" targetId="31a2-bac3-73c8-e7fe" type="profile"/>
-        <infoLink id="85c0-a9e7-efa8-69f9" name="Explosive Collapse" hidden="false" targetId="af3d-83e5-57d5-14c6" type="rule"/>
-      </infoLinks>
+      <profiles>
+        <profile id="6471-db13-29b7-f98b" name="Particle Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="db9a-d7f1-d4a1-4c6d" name="Explosive Collapse" hidden="false">
+          <description>If this weapon targets and destroys an enemy model, other models within 2&quot; of the model targeted suffer a POW 4 damage roll.</description>
+        </rule>
+      </rules>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3cc2-32aa-c726-779a" name="Fusion Drill" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f620-0b56-9bf7-932e" name="Fusion Drill" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="7519-1333-8f42-ed70" name="Fusion Drill" hidden="false" targetId="85c7-d579-c25d-9aed" type="profile"/>
+        <infoLink id="caf4-40d4-6319-d518" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="d1bc-3732-9ead-cc64" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3807-0a5f-9501-0ed2" name="Impaler" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="aefc-bacc-4441-7450" name="Impaler" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="cff9-4e2d-f62b-235d" name="Impaler" hidden="false" targetId="452f-bab9-547c-6535" type="profile"/>
-        <infoLink id="2007-040a-28d0-82fd" name="Armor-Piercing" hidden="false" targetId="4a62-dd5f-b896-d12c" type="rule"/>
+        <infoLink id="2007-040a-28d0-82fd" name="Armor Piercing" hidden="false" targetId="4a62-dd5f-b896-d12c" type="rule"/>
+        <infoLink id="d46b-a2e7-1f49-77cd" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="abca-226a-347c-abd9" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6485-7691-7900-71d5" name="Particle Accelerator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="eeb3-9beb-7c74-12e2" name="Particle Accelerator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="2b88-49ee-7ae5-d2cb" name="Particle Accelerator" hidden="false" targetId="477f-11ea-1ce7-0b2f" type="profile"/>
         <infoLink id="2f21-9e49-84e2-cf0e" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+        <infoLink id="af5f-016c-2317-145c" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="bdf9-00fb-8bda-ac4a" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e9bf-7176-b61d-4e73" name="Slug Gun" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="197c-3a65-69c8-5898" name="Slug Gun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="be82-e669-baca-f529" name="Slug Gun" hidden="false" targetId="8904-f5d5-d3c3-2fe2" type="profile"/>
         <infoLink id="9a6e-de8e-b8e8-0e0a" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+        <infoLink id="e19d-4244-14eb-ac12" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="2da2-8c27-1415-130f" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="1.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="92f0-ed13-0a2c-ecae" name="Blazer" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="776d-1f71-83f7-5b1b" name="Blazer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="cc48-9a79-5ffe-a630" name="Blazer" hidden="false" targetId="62dc-52d7-5d0d-7b1b" type="profile"/>
         <infoLink id="8f11-40b9-7c16-0ad6" name="Fire" hidden="false" targetId="c2c4-1eac-f24e-09f5" type="rule"/>
         <infoLink id="52c4-6692-bbb3-bfc9" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+        <infoLink id="526a-2a8d-5085-c69b" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="12fd-75dd-a80f-4abd" name="Beam" hidden="false" targetId="416c-f81b-c698-5f02" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="3.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="28df-111d-3305-ece5" name="Wildflower" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9411-c84b-1f14-61e1" name="Wildflower" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">-</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="0e58-c89a-0aa9-1ce6" name="Eruption" hidden="false" targetId="fbcf-7d2a-48f0-4286" type="rule"/>
+        <infoLink id="0e58-c89a-0aa9-1ce6" name="Eruption" hidden="false" targetId="7ad9-2c28-d741-da94" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="2.0"/>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a69e-85de-6f7e-c93a" name="Rock Buster" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b3d2-6646-b0ac-7431" name="Rock Buster" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="47e1-15e4-07eb-700e" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="885e-e5c3-843a-cb07" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="f889-8249-9f3c-66e1" name="Armor Piercing" hidden="false" targetId="4a62-dd5f-b896-d12c" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1370-1442-954f-4994" name="Cyclone Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="59c8-2604-f080-32b7" name="Cyclone Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8f79-46bd-ad87-74b3" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="4b82-db1e-c52e-1dd9" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="c9c8-9c3d-0121-e055" name="Strafe" hidden="false" targetId="77e6-c811-aef4-ee7f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="177d-e828-357a-dec8" name="Vortex Missile" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="d5ed-45e6-1607-0c87" name="Vortex Missile" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="11f4-d746-1ea0-a519" name="Null Blast (Spike)" hidden="false">
+          <description>Immediately after hitting a target with this weapon, this model can spike once to clear 1 Arc from the model hit and from all models within 2&quot; of it.</description>
+        </rule>
+      </rules>
+      <infoGroups>
+        <infoGroup id="4942-dc1f-584c-4cab" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="3581-7b03-3117-4583" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="070a-0028-cc1c-b85e" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="6961-bf15-9b49-ec48" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="22e6-7312-979d-4404" name="Slug Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4853-4263-e49f-190f" name="Slug Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2bbc-a01f-e75b-ff99" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="e2c2-5fc8-9716-67f2" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="d20d-f402-c29f-aa4f" name="Repulsor" hidden="false" targetId="83ee-82fd-698b-c4e6" type="rule"/>
+        <infoLink id="f091-c0f1-3729-6eb8" name="Turret" hidden="false" targetId="fdfc-0a81-546d-2c31" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e185-7f38-64a3-5dfe" name="Talon Mk II" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e332-374f-ebeb-9bfc" name="Talon Mk II" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup id="a2cd-0290-1ddc-f711" name="Energy Type" hidden="false">
+          <infoLinks>
+            <infoLink id="8ab8-e0c8-8162-7643" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+            <infoLink id="bbf3-68b0-c4ee-ce81" name="Explosion" hidden="false" targetId="f7b6-783e-1ae9-465d" type="rule"/>
+          </infoLinks>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="d31e-89bc-7ce9-d4c4" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="57d4-9e3c-6c7a-dfd6" name="Anti-Air" hidden="false" targetId="8758-53ba-60e8-19ab" type="rule"/>
+        <infoLink id="10c2-2252-79e0-32ae" name="Mechanikal Optics (Charge)" hidden="false" targetId="7995-7ab0-c3da-f21e" type="rule"/>
+        <infoLink id="af19-858a-1eed-3022" name="Turret" hidden="false" targetId="fdfc-0a81-546d-2c31" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
-  <sharedProfiles>
-    <profile id="da9e-e7f3-bd55-b883" name="Combat Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="f54d-f3a0-98f9-4a16" name="Handgun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="0ee5-8bc2-a046-94ba" name="Battle Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Mechanikal Optics (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="c08c-1fef-6c35-56f9" name="Null Detonator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">6</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">-</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Nullifier</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a7eb-f0e9-f06e-de5d" name="Fusion Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="b5f5-c5af-2b1d-db71" name="Ripper" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">2</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="a099-d402-794a-98f5" name="Talon Rocket Pod" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic and Explosion</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Blast Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9c57-7e77-2600-e924" name="Rail Gun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">18</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Arc Booster (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d62d-05b1-b29b-d144" name="Flame Thrower" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Fire</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Spray Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="b4dc-c2f5-7af3-717f" name="Sniper Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">15</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Arc Booster (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="bb53-9901-54b9-acb5" name="Battle Staff" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Repulsor</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="85c7-d579-c25d-9aed" name="Fusion Drill" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="31a2-bac3-73c8-e7fe" name="Particle Cannon" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">6</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Explosive Collapse</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ab3d-c807-a789-e8cc" name="Fusion Torch" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">High Intensity (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="cb9e-0215-1cf9-2dc5" name="Wrench" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="c2ec-3d61-5328-0177" name="Talon Rocket Launcher" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Blast Weapon, Targeter (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1ad5-cbfa-6279-0f86" name="Arclock Pistol" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Attack Mode (Arclock Pistol)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="452f-bab9-547c-6535" name="Impaler" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">2</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Armor-Piercing</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="477f-11ea-1ce7-0b2f" name="Particle Accelerator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">1</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">High Intensity (Charge)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="8904-f5d5-d3c3-2fe2" name="Slug Gun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Repulsor</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="62dc-52d7-5d0d-7b1b" name="Blazer" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Beam</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">14</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Fire, Strafe</characteristic>
-      </characteristics>
-    </profile>
-  </sharedProfiles>
+  <sharedRules>
+    <rule id="7995-7ab0-c3da-f21e" name="Mechanikal Optics (Charge)" hidden="false">
+      <description>While this model is charged, this weapon gains +4 RNG.</description>
+    </rule>
+    <rule id="1a75-dcac-9578-c7f9" name="Cleave" hidden="false">
+      <description>If this model destroys an enemy model with an attack made with this weapon, it can immediately make an additional attack with this weapon. Attacks granted by Cleave cannot generate further additional attacks.</description>
+    </rule>
+    <rule id="a339-fbad-c256-4d89" name="Arc Booster (Spike)" hidden="false">
+      <description>When attacking with this weapon, before making a damage roll, this model can spike to cause the target of the attack to suffer -1 ARM until the attack is resolved.</description>
+    </rule>
+    <rule id="7ad9-2c28-d741-da94" name="Eruption" hidden="false">
+      <description>When this model chooses to use Eruption it makes its attacks during its activation. If it does so, all other models within 3&quot; of it each suffer a POW 3 explosion damage roll.</description>
+    </rule>
+    <rule id="8758-53ba-60e8-19ab" name="Anti-Air" hidden="false">
+      <description>When attacking modeles with Flight with this weapon, add two ACTION dice to attack rolls.</description>
+    </rule>
+    <rule id="51e5-2ce6-9605-ac40" name="Maelstrom Activator (Spike)" hidden="false">
+      <description>During this unit&apos;s activation, immediately after completing its attacks this model can spike to make one additional attack with each of its weapons.</description>
+    </rule>
+    <rule id="235c-e23b-4228-be38" name="Guns Ready" hidden="false">
+      <description>When an enemy model moves into the area within 10&quot; of the Razorbat and ends it&apos;s movement, the Razorbat can make one attack targeting the enemy model. The maneuver expires at the start of this units next activation, or immediately after this model makes an attack as the result of Guns Ready.</description>
+    </rule>
+    <rule id="dcdf-5590-dfa6-a721" name="Hit the Jump" hidden="false">
+      <description>The Razorbat gains Flight this activation. This maneuver expires at the end of this activation.</description>
+    </rule>
+    <rule id="6049-7ae2-4745-66d9" name="Stand and Deliver" hidden="false">
+      <description>The Razorbot cannot advance this activation. The Razorbat adds one POWER die to ranged attack rolls. This maneuver expires at the end of this activation.</description>
+    </rule>
+    <rule id="fdfc-0a81-546d-2c31" name="Turret" hidden="false">
+      <description>The model gains +1 RAT when resolving attack rolls for this weapon.</description>
+    </rule>
+  </sharedRules>
 </catalogue>

--- a/Warcaster_Neo-Mechanika.gst
+++ b/Warcaster_Neo-Mechanika.gst
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="6e64-0ab9-a430-a976" name="Warcaster: Neo-Mechanika" revision="4" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="6e64-0ab9-a430-a976" name="Warcaster: Neo-Mechanika" revision="3" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+  <publications>
+    <publication id="2264-1200-2648-8677" name="Core Rules" shortName="Core Rules" publisher="KS1"/>
+    <publication id="216d-9058-fe0b-7be3" name="Collision Course" shortName="Collision Course" publisher="KS2"/>
+  </publications>
   <costTypes>
     <costType id="ecbb-d452-36d4-0214" name="Weapon Points" defaultCostLimit="-1.0" hidden="false"/>
   </costTypes>
@@ -41,11 +45,30 @@
     </profileType>
     <profileType id="3601-946f-42f1-0f5c" name="Weapon">
       <characteristicTypes>
-        <characteristicType id="bd77-31aa-5209-2b6c" name="DMG"/>
-        <characteristicType id="684a-ebe0-b4ae-1d02" name="TYP"/>
         <characteristicType id="a6dd-0c75-98a7-e08a" name="RNG"/>
         <characteristicType id="9750-e740-35f4-1cf6" name="POW"/>
-        <characteristicType id="b9f6-e564-4386-9830" name="Rules"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="f21f-e3fc-861e-7041" name="Mantlet">
+      <characteristicTypes>
+        <characteristicType id="9a1a-1996-43a0-5ebf" name="SPD"/>
+        <characteristicType id="ef7d-7e69-bb45-465a" name="MAT"/>
+        <characteristicType id="0dee-6f34-8704-e237" name="RAT"/>
+        <characteristicType id="7629-6783-48fa-04fb" name="DEF"/>
+        <characteristicType id="8838-aacd-9ec7-99b1" name="ARM"/>
+        <characteristicType id="c150-c260-a91e-5bdb" name="DMG"/>
+        <characteristicType id="e127-231f-27ff-e6a4" name="CST"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="8503-75a8-8ab2-161b" name="Vehicle">
+      <characteristicTypes>
+        <characteristicType id="d513-8b95-8e8b-9643" name="SPD"/>
+        <characteristicType id="dd71-a3b1-b5d2-4126" name="MAT"/>
+        <characteristicType id="4972-6b8a-4cc9-a39d" name="RAT"/>
+        <characteristicType id="5d4e-e604-9d25-f35d" name="DEF"/>
+        <characteristicType id="5dd6-51ae-08e3-2c18" name="ARM"/>
+        <characteristicType id="804d-3ef2-0e46-d938" name="DMG"/>
+        <characteristicType id="c28f-24c8-5446-8b51" name="CST"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -60,6 +83,7 @@
       </constraints>
     </categoryEntry>
     <categoryEntry id="fa79-7113-8f14-037f" name="Attachments" hidden="false"/>
+    <categoryEntry id="2046-8d8f-ce5e-6153" name="Mantlet" publicationId="216d-9058-fe0b-7be3" page="17" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="9d06-65d5-e823-50f0" name="Skirmish" hidden="false">
@@ -84,6 +108,11 @@
         <categoryLink id="3359-e956-34c2-eb54" name="Attachments" hidden="false" targetId="fa79-7113-8f14-037f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61e2-8a1e-3116-d7d7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="262a-f8b5-d2d6-654b" name="Mantlet" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e69d-eb32-dc87-abac" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -112,6 +141,11 @@
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12f9-78e4-47ce-0537" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="fb68-01a9-593d-74c5" name="Mantlet" hidden="false" targetId="2046-8d8f-ce5e-6153" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a4-f2c3-9850-5377" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -134,7 +168,7 @@
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2409-20b7-fd32-ff5d" name="Captain Jax Redblade" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="2409-20b7-fd32-ff5d" name="Captain Jax Redblade" publicationId="2264-1200-2648-8677" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec49-8852-fb26-a82b" type="max"/>
       </constraints>
@@ -153,8 +187,6 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="a991-d130-a089-af9a" name="Fusion Sword" hidden="false" targetId="f41f-4dac-afb3-2b9b" type="profile"/>
-        <infoLink id="f20e-a3f4-9452-5c2e" name="Magnun" hidden="false" targetId="5823-c72a-bd39-bc1b" type="profile"/>
         <infoLink id="4cf1-5d5d-d611-f7d6" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
         <infoLink id="1341-3284-1cb7-fd70" name="Riposte" hidden="false" targetId="6cf6-e985-c044-dfd5" type="rule"/>
         <infoLink id="6afe-9a43-1e4a-4d8e" name="Refractor Field" hidden="false" targetId="309a-b487-006c-6310" type="rule"/>
@@ -163,11 +195,25 @@
       <categoryLinks>
         <categoryLink id="e038-cc7d-3182-15cd" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="8721-f5f9-74d3-c92a" name="Magnum" hidden="false" collective="false" import="true" targetId="a385-0d0d-e7c6-1bb4" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8bb-6542-b866-a024" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e2e-f558-cfd1-765c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="34fa-57cf-9cc4-7735" name="Fusion Sword" hidden="false" collective="false" import="true" targetId="dd0d-1af9-772b-2a66" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="830e-166d-f308-c2c2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="addf-d831-2fa2-3bb3" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06b9-ea95-5cd2-5bd2" name="Baron Cassius Mooregrave" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="06b9-ea95-5cd2-5bd2" name="Baron Cassius Mooregrave" publicationId="2264-1200-2648-8677" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecf5-b1f8-f790-001a" type="max"/>
       </constraints>
@@ -186,23 +232,32 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="c86c-8bb9-c264-b1e0" name="Magnun" hidden="false" targetId="5823-c72a-bd39-bc1b" type="profile"/>
-        <infoLink id="27a1-ad72-f563-6be4" name="Oblivion" hidden="false" targetId="7a8e-8657-abf4-9a78" type="profile"/>
         <infoLink id="2b03-d511-f415-0269" name="Living Terror" hidden="false" targetId="4358-272a-6d5f-a71d" type="rule"/>
         <infoLink id="507b-ba97-d65b-d437" name="Phase Stalker (Spike)" hidden="false" targetId="b6f8-55ca-8c6e-f088" type="rule"/>
         <infoLink id="24de-7ad1-b97a-7287" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
-        <infoLink id="c123-9ca9-28d2-7c8b" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
-        <infoLink id="a644-696f-da2c-fd81" name="Gorge" hidden="false" targetId="14b7-3e35-6f9c-bebe" type="rule"/>
-        <infoLink id="def6-da9e-203b-4f35" name="Siphon Power" hidden="false" targetId="4da9-a09e-9260-e1ed" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bf6d-c67e-cc1b-c358" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
       </categoryLinks>
+      <entryLinks>
+        <entryLink id="6bd2-2324-43db-5fd0" name="Magnum" hidden="false" collective="false" import="true" targetId="a385-0d0d-e7c6-1bb4" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9725-1573-a953-323e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4b2-be88-d154-ad2c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6a8b-592a-de3e-c929" name="Oblivion" hidden="false" collective="false" import="true" targetId="982a-1bfb-7c11-b7b9" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b0b-d35b-baff-022c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387a-45e4-556b-699d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d57b-15ce-482f-c16c" name="Voitek Sudal, Bounty Hunter" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="d57b-15ce-482f-c16c" name="Voitek Sudal, Bounty Hunter" publicationId="2264-1200-2648-8677" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b613-5438-6269-1e9d" type="max"/>
       </constraints>
@@ -221,19 +276,423 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="63e3-321f-cec7-0a96" name="Force Constrictor" hidden="false" targetId="fb56-1a6a-27da-80fc" type="profile"/>
-        <infoLink id="5a40-1498-161b-f4fd" name="Null Detonator" hidden="false" targetId="1b2e-337d-d5c1-7b91" type="profile"/>
-        <infoLink id="0693-cb5f-ab7d-64cd" name="Combat Blade" hidden="false" targetId="a3bf-d8a7-97e1-c766" type="profile"/>
         <infoLink id="3569-40c7-1b95-4b07" name="Gate Jammer (Charge)" hidden="false" targetId="07c2-cd31-0208-e66a" type="rule"/>
         <infoLink id="e7ba-a5ce-3239-c7d1" name="Pathfinder" hidden="false" targetId="2060-8a7e-1170-aae4" type="rule"/>
         <infoLink id="b2f4-efc0-d595-bad5" name="Stealth" hidden="false" targetId="1140-dc03-6d45-8cd7" type="rule"/>
         <infoLink id="5a35-d1a9-4149-a581" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
-        <infoLink id="baea-325e-3eee-37e0" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
-        <infoLink id="d81b-b675-94fc-b6d6" name="Nullifier" hidden="false" targetId="24ab-84f6-b1d5-3fba" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a2b4-18e2-2e94-4d91" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6752-c80c-6766-0a53" name="Force Constrictor" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fff6-99e5-411d-8ca4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c3-e471-1046-602e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dd14-9c93-25a6-16a5" name="Force Constrictor" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="5341-e6d0-e445-95bd" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="36e7-e604-2241-0d58" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+            <infoLink id="1405-d9a4-43ef-9680" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="b020-a94e-374d-87d3" name="Combat Blade" hidden="false" collective="false" import="true" targetId="bad8-a8e3-7f74-4585" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8780-17af-32f5-abb6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da9b-e8bf-2dc1-f911" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a332-7685-25cb-13ed" name="Null Detonator" hidden="false" collective="false" import="true" targetId="b93c-4a3a-7273-5ec8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd71-1972-b675-69aa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f5-c7cf-4308-8f6c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="931a-ec9f-d521-ea13" name="Evasive Action" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="9972-0e66-1b60-e294" name="Evasive Action" hidden="false" targetId="9b9d-84ff-3a95-2643" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afbe-3ad8-68cc-021f" name="Doctor Mira Hurst" publicationId="216d-9058-fe0b-7be3" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2258-d764-f175-4a64" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0b68-c5c9-cfdc-b65d" name="Doctor Mira Hurst" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">3</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">3</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">4</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">3</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">2</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="17c5-c78f-1e02-e510" name="Arc Amplifier (Charge)" hidden="false">
+          <description>While this model is charged, when another friendly unit activates within 10&quot; of this model you can charge the other unit with up to one Arc.</description>
+        </rule>
+        <rule id="fa28-bb39-adf3-ec6e" name="Void Disruptor (Spike)" hidden="false">
+          <description>This model can spike once during it&apos;s activation to clear 1 Arc from each enemy unit within 5&quot; of this model.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c9c4-02d2-c3b1-07cf" name="Revelator" hidden="false" targetId="c8f4-25c2-f013-c8b2" type="rule"/>
+        <infoLink id="c1da-c027-7412-180a" name="Aegis Field (Charge)" hidden="false" targetId="adcf-4047-c0a2-154b" type="rule"/>
+        <infoLink id="d004-e011-bd5a-cc85" name="Arc Exchange" hidden="false" targetId="089a-a7eb-cae0-9775" type="rule"/>
+        <infoLink id="08e2-a262-ff61-6594" name="Psycho Relay" hidden="false" targetId="4769-9fbb-0de5-9570" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8d84-9ee4-0f4c-a9a6" name="Heroes" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f949-db28-d61a-ed8c" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="fca2-fc5f-d8fc-f2ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="954d-2c89-29c5-0d3f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee74-3ee0-32bb-76b6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fca2-fc5f-d8fc-f2ad" name="Assault Rifle" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="22da-ed23-167d-6d76" name="Assault Rifle" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e4a2-eccf-76b9-5f54" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="0b23-1d3e-abe4-4b2b" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a385-0d0d-e7c6-1bb4" name="Magnum" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7c00-dd6b-aa10-7975" name="Magnum" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="66e0-f459-bfe8-1055" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+        <infoLink id="dee8-8c39-ce78-8377" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="982a-1bfb-7c11-b7b9" name="Oblivion" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="14e3-3214-1e7d-1e29" name="Oblivion" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="06cd-1e22-4664-6320" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="5586-3d63-2a05-8590" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="15ad-6fa6-8b5b-3f1d" name="High Intensity (Charge)" hidden="false" targetId="b3c5-5b94-5cca-52ed" type="rule"/>
+        <infoLink id="7695-59cd-f1da-850f" name="Gorge" hidden="false" targetId="14b7-3e35-6f9c-bebe" type="rule"/>
+        <infoLink id="a894-226d-7b64-684e" name="Siphon Power" hidden="false" targetId="4da9-a09e-9260-e1ed" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dd0d-1af9-772b-2a66" name="Fusion Sword" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9b79-c950-e6d5-bbc3" name="Fusion Sword" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2fe5-4f36-1a83-d5ea" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="b97a-cd76-c7c2-4825" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bad8-a8e3-7f74-4585" name="Combat Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2820-c135-aa1e-2eb2" name="Combat Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="92c5-14cb-1453-f24b" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+        <infoLink id="9d85-ae49-bf3b-eb24" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b93c-4a3a-7273-5ec8" name="Null Detonator" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9049-5400-7cf9-2e3d" name="Null Detonator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">6</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a977-528e-46a6-ca8e" name="Nullifier" hidden="false">
+          <description>This attack causes no damage. Instead clear 1 ARC from the unit or void gate hit by the weapon.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3729-a585-588d-1457" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="fe18-a212-9bd0-0081" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ddfc-dacc-8d2e-265f" name="Fusion Blade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a48e-6705-7ca3-db53" name="Fusion Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8513-a812-f7c9-9d7e" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+        <infoLink id="9b1b-ecbe-f41e-6ec7" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ed8-0d73-fb42-d501" name="Harlan Sek, The Curator" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ba-c268-ce02-d5b2" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="885a-24e6-b13a-2181" name="Harlan Sek, The Curator" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">5</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">4</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">4</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">2</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">3</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b122-15c1-9037-113c" name="Environmental Suit" hidden="false">
+          <description>This model is immune to Cold, Corrosion and Fire damage. This model never suffers the corrosion or fire continuous effects.</description>
+        </rule>
+      </rules>
+      <infoGroups>
+        <infoGroup id="944a-57fd-24bf-66a0" name="Alien Artifacts" hidden="false">
+          <rules>
+            <rule id="db41-dee9-e74b-67d0" name="Penumbral Agitator" hidden="false">
+              <description>Look at your opponents hand of Cypher cards. Chose one Cypher card to discard.</description>
+            </rule>
+            <rule id="837c-23c9-cbe7-fa90" name="Quantum Harmonizer" hidden="false">
+              <description>Roll one ACTION die for this model and each friendly model within 5&quot; of it. Roll separately for each model. Remove 1 damage from each model for each strike rolled.</description>
+            </rule>
+            <rule id="3b8c-666f-b549-c2d0" name="Shadow Conductor" hidden="false">
+              <description>Reposition this model to any location within 2&quot; of any friendly model.</description>
+            </rule>
+          </rules>
+        </infoGroup>
+      </infoGroups>
+      <infoLinks>
+        <infoLink id="7b67-f921-3d7d-3f33" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
+        <infoLink id="7700-c5de-e19f-95b8" name="Dynamic Accelerator (Charge)" hidden="false" targetId="592d-4c1c-98fb-122f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d91d-d7d1-ec01-bbf2" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="56dc-e9ff-7068-9100" name="Flux Disruptor" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ce-48ae-d9d3-1ab3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a8c-c5b0-8bd4-b91c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="91c7-9575-bbb3-67f1" name="Flux Disruptor" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">12</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="19f0-fb91-d486-5930" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="f759-b8aa-2d66-50e0" name="Energy" hidden="false" targetId="f884-bbdf-1755-7f40" type="rule"/>
+            <infoLink id="3c0e-7e68-4951-8e20" name="Stun Module (Spike)" hidden="false" targetId="74d3-0293-89c9-ba64" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="650a-04d7-edb6-5539" name="Fusion Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="8362-1ca6-cf24-4ed3" name="Fusion Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="1585-86a8-7431-a0eb" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="3261-7252-4bc1-7f7d" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4466-6c6e-5b1e-2620" name="Handgun" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0a38-b061-3f11-b139" name="Handgun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+          <characteristics>
+            <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
+            <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3fb2-49e9-9f83-a868" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+        <infoLink id="c4a1-b49f-435f-11c5" name="Ballistic" hidden="false" targetId="4c03-2674-46a3-4674" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="413f-3332-67a2-8853" name="Corebus" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5837-17c0-bdf4-6796" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="60d1-3f6f-4334-d3bf" name="Corebus" hidden="false" typeId="5643-55ad-cf84-ac2a" typeName="Solo">
+          <characteristics>
+            <characteristic name="SPD" typeId="e7f7-8a52-6885-3006">6</characteristic>
+            <characteristic name="MAT" typeId="b4d4-69fe-dd8c-7c12">4</characteristic>
+            <characteristic name="RAT" typeId="3127-5d41-efdc-a87d">4</characteristic>
+            <characteristic name="DEF" typeId="8355-c44c-010d-9a88">2</characteristic>
+            <characteristic name="ARM" typeId="d0c1-80eb-f256-6b2f">4</characteristic>
+            <characteristic name="FOC" typeId="b34d-3c07-68b0-ec80">-</characteristic>
+            <characteristic name="DMG" typeId="76be-0810-d006-512c">3</characteristic>
+            <characteristic name="CST" typeId="50cb-a3c5-93ef-21c0">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1696-3bac-d462-3f68" name="Gladiator" hidden="false">
+          <description>This model adds two POWER dice to it&apos;s melee attack rolls targeting enemy warjacks.</description>
+        </rule>
+        <rule id="5c81-7308-a7f8-a781" name="Guardian" hidden="false">
+          <description>When a friendly model is targeted and hit by an enemy attack while within 5&quot; of this model, you can choose to have this model be hit instead.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b96c-f145-80cd-3fad" name="Weapon Expert" hidden="false" targetId="ed37-1d75-e270-e479" type="rule"/>
+        <infoLink id="da2b-5f96-2a67-68b9" name="Dynamic Accelerator (Charge)" hidden="false" targetId="592d-4c1c-98fb-122f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ab6a-6865-2cc3-e733" name="New CategoryLink" hidden="false" targetId="cc26-f6fc-643b-1352" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6760-d2fe-c5b3-ca2c" name="Fist" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5dd-2968-f2c8-9ac5" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f58f-c56f-4a08-aa52" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a3bf-aabf-a3d6-382a" name="Fist" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="5bbb-ab52-cbc8-87e6" name="Melee" hidden="false" targetId="6c5c-9284-ad97-ece8" type="rule"/>
+            <infoLink id="b7e1-727f-59d5-3e30" name="Kinetic" hidden="false" targetId="9e4e-f8cd-00eb-cad9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2de5-aa81-cc0b-400d" name="Teleforce Blaster" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b91-d5a2-7b68-e78b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9792-20bd-b0dc-5dfb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4b6e-4d0a-fbdb-100a" name="Teleforce Blaster" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
+              <characteristics>
+                <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
+                <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="eb68-a817-b1ae-92e9" name="Ranged" hidden="false" targetId="15d3-b3f8-98ef-48bc" type="rule"/>
+            <infoLink id="4cdf-d59c-c42d-0a09" name="Force" hidden="false" targetId="8373-ff2e-7769-c5a7" type="rule"/>
+            <infoLink id="174a-43dd-0873-72ed" name="Force Ram (Spike)" hidden="false" targetId="c2f8-48d9-d6ed-1bdf" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="Weapon Points" typeId="ecbb-d452-36d4-0214" value="0.0"/>
       </costs>
@@ -251,7 +710,15 @@
           </constraints>
           <rules>
             <rule id="314f-be3c-b3ac-adc0" name="-Cypher- Cryo Lock" hidden="false">
-              <description>Fury: POW(-) Target an enemy unit model in range. Make a Fury attack roll against the target model. If this attack hits, it does no damage. Instead, the hit unit gains an activation token. Models that are immune to cold damage are not affected by this Fury.</description>
+              <description>Fury:
+
+POW(-)
+
+Target an enemy unit model in range.
+
+Make a Fury attack roll against the target model. If this attack hits, it does no damage. Instead, the hit unit gains an activation token.
+
+Models that are immune to cold damage are not affected by this Fury.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -267,7 +734,13 @@
           </constraints>
           <rules>
             <rule id="b734-dab7-6bbc-2d8b" name="-Cypher- Velocity Projector" hidden="false">
-              <description>Fury: POW(4) Target an enemy model in range. Make an attack roll against the target model. If the attack hits, the model is slammed 3&quot; directly away from the model the fury is being channeled through before suffering a damage roll. Models with an equal or smaller base that are contacted by the slammed model suffer a collateral damage roll equal to the POW of this card. This Fury causes force damage.</description>
+              <description>Fury:
+
+POW(4)
+
+Target an enemy model in range. Make an attack roll against the target model. If the attack hits, the model is slammed 3&quot; directly away from the model the fury is being channeled through before suffering a damage roll. Models with an equal or smaller base that are contacted by the slammed model suffer a collateral damage roll equal to the POW of this card.
+
+This Fury causes force damage.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -283,7 +756,13 @@
           </constraints>
           <rules>
             <rule id="8fdf-ed71-0724-864a" name="-Cypher- Pyrokinetic Surge" hidden="false">
-              <description>Fury: POW(3) Target an enemy model in range. Make an attack roll against the target model. If the attack hits, the model hit suffers the Fire continuous effect in addition to suffering a damage roll. This Fury causes fire damage.</description>
+              <description>Fury:
+
+POW(3)
+
+Target an enemy model in range. Make an attack roll against the target model. If the attack hits, the model hit suffers the Fire continuous effect in addition to suffering a damage roll.
+
+This Fury causes fire damage.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -299,7 +778,13 @@
           </constraints>
           <rules>
             <rule id="9287-3947-eced-db13" name="-Cypher- Null Collider" hidden="false">
-              <description>Fury: POW(3) Target an enemy model in range. Make an attack roll against the target model. If the attack hits, in addition to a damage roll, clear 1 Arc from the unit or void gate hit. This Fury causes energy damage.</description>
+              <description>Fury:
+
+POW(3)
+
+Target an enemy model in range. Make an attack roll against the target model. If the attack hits, in addition to a damage roll, clear 1 Arc from the unit or void gate hit.
+
+This Fury causes energy damage.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -315,7 +800,13 @@
           </constraints>
           <rules>
             <rule id="545c-8f65-b91b-276f" name="-Cypher- Malediction Rubric" hidden="false">
-              <description>Fury: POW(4) Target enemy model unit in range. Make an attack roll against the target model. If the attack hits, enemy Cypher cards on the unit hit expire and the model hit suffers a damage roll. This Fury causes energy damage.</description>
+              <description>Fury:
+
+POW(4)
+
+Target enemy model unit in range. Make an attack roll against the target model. If the attack hits, enemy Cypher cards on the unit hit expire and the model hit suffers a damage roll.
+
+This Fury causes energy damage.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -331,7 +822,13 @@
           </constraints>
           <rules>
             <rule id="983a-76bf-f42c-8125" name="-Cypher- Instability Equation" hidden="false">
-              <description>Fury: POW(4) Target enemy model unit in range. When this attack hits its target, resolve the attack against the target as normal. Additionally, when this attack hits its target the two models closest to the target that are also within 2&quot; of it suffer blast damage rolls equal to the POW of this attack. If this attack misses its target, the target still suffers a blast damage roll equal to the POW of this attack. This Fury causes blast damage.</description>
+              <description>Fury:
+
+POW(4)
+
+Target enemy model unit in range. When this attack hits its target, resolve the attack against the target as normal. Additionally, when this attack hits its target the two models closest to the target that are also within 2&quot; of it suffer blast damage rolls equal to the POW of this attack. If this attack misses its target, the target still suffers a blast damage roll equal to the POW of this attack.
+
+This Fury causes blast damage.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -354,7 +851,11 @@
           </constraints>
           <rules>
             <rule id="6644-9e13-3735-cadd" name="-Cypher- Plexus Densifier" hidden="false">
-              <description>Geometric: Target a frinedly squad. The squad gains +2 ARM but suffers -1 SPD. Plexus Densifier expires at the end of the Pulse round.</description>
+              <description>Geometric:
+
+Target a friendly squad. The squad gains +2 ARM but suffers -1 SPD.
+
+Plexus Densifier expires at the end of the Pulse round.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -370,7 +871,9 @@
           </constraints>
           <rules>
             <rule id="ebf9-470b-c67f-3ca8" name="-Cypher- Displacement Index" hidden="false">
-              <description>Geometric: Target a frinedly squad. The squad can immediately move up to 3&quot;.</description>
+              <description>Geometric:
+
+Target a friendly squad. The squad can immediately move up to 3&quot;.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -386,7 +889,11 @@
           </constraints>
           <rules>
             <rule id="518e-32e1-83e4-a9ac" name="-Cypher- Force Barrier" hidden="false">
-              <description>Geometric: Target a frindly squad. Affected models gain cover. Force Barrier expires at the end of the Pulse round.</description>
+              <description>Geometric:
+
+Target a friendly squad. Affected models gain cover.
+
+Force Barrier expires at the end of the Pulse round.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -402,7 +909,13 @@
           </constraints>
           <rules>
             <rule id="2499-312a-7eb1-b53a" name="-Cypher- Reiteration Complex" hidden="false">
-              <description>Geometric: Target a frindly squad. During the squad&apos;s activation, each model in the squad can make one additional ranged attack. Reiteration Complex expires at the end of this turn.</description>
+              <description>Geometric:
+
+Target a friendly squad.
+
+During the squad&apos;s activation, each model in the squad can make one additional ranged attack.
+
+Reiteration Complex expires at the end of this turn.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -418,7 +931,9 @@
           </constraints>
           <rules>
             <rule id="9925-4d2a-f8e2-1b57" name="-Cypher- Mortality Destabilizer" hidden="false">
-              <description>Geometric: Target a friendly squad. Return one destroyed non-attachment model to this squad. Place the returned model within 2&quot; of another model in the squad.</description>
+              <description>Geometric:
+
+Target a friendly squad. Return one destroyed non-attachment model to this squad. Place the returned model within 2&quot; of another model in the squad.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -434,7 +949,11 @@
           </constraints>
           <rules>
             <rule id="d0a6-6409-8191-2da5" name="-Cypher- Temporal Cycle" hidden="false">
-              <description>Geometric: Target a frinedly squad. Remove the activation token from this squad.</description>
+              <description>Geometric:
+
+Target a friendly squad.
+
+Remove the activation token from this squad.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -457,7 +976,11 @@
           </constraints>
           <rules>
             <rule id="ee72-b3ee-8f3b-6359" name="-Cypher- Recall Initiative" hidden="false">
-              <description>Harmonic: Target a friendly unit. Recall the unit.</description>
+              <description>Harmonic:
+
+Target a friendly unit.
+
+Recall the unit.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -473,7 +996,13 @@
           </constraints>
           <rules>
             <rule id="d47f-dc0c-4b66-e37b" name="-Cypher- Divination Algorithm" hidden="false">
-              <description>Harmonic: Target a frinedly unit. This unit&apos;s ranged weapons gain +1 RNG and POW. Divination Algorithm expires at the end of the Pulse round.</description>
+              <description>Harmonic:
+
+Target a friendly unit.
+
+This unit&apos;s ranged weapons gain +1 RNG and POW.
+
+Divination Algorithm expires at the end of the Pulse round.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -489,7 +1018,13 @@
           </constraints>
           <rules>
             <rule id="85dd-31bf-f453-a09c" name="-Cypher- Revelation Matrix" hidden="false">
-              <description>Harmonic: Target friendly unit. The unit can ignore the Stealth special rule. Revelation Matrix expires at the end of the Pulse round.</description>
+              <description>Harmonic:
+
+Target friendly unit.
+
+The unit can ignore the Stealth special rule.
+
+Revelation Matrix expires at the end of the Pulse round.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -505,7 +1040,11 @@
           </constraints>
           <rules>
             <rule id="a511-9340-fe6f-0bb9" name="-Cypher- Arcane Synthesis" hidden="false">
-              <description>Harmonic: Target a friendly unit. You can immediately charge the unit with any amount of Arc up to its limit.</description>
+              <description>Harmonic:
+
+Target a friendly unit.
+
+You can immediately charge the unit with any amount of Arc up to its limit.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -521,7 +1060,11 @@
           </constraints>
           <rules>
             <rule id="99c3-5c53-b77d-44db" name="-Cypher- Encrypted Command" hidden="false">
-              <description>Harmonic: Target a friendly solo. Remove the activation token from the solo.</description>
+              <description>Harmonic:
+
+Target a friendly solo.
+
+Remove the activation token from the solo.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -537,7 +1080,11 @@
           </constraints>
           <rules>
             <rule id="0e39-ca6a-7d14-8446" name="-Cypher- Aggression Theorem" hidden="false">
-              <description>Harmonic: Target friendly unit model. The target model can immediately make on melee or ranged attack.</description>
+              <description>Harmonic:
+
+Target friendly unit model.
+
+The target model can immediately make on melee or ranged attack.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -560,7 +1107,13 @@
           </constraints>
           <rules>
             <rule id="d907-67f9-9f91-baf7" name="-Cypher- Interdiction Protocol" hidden="false">
-              <description>Overdrive: Target a friendly warjack. Friendly warrior models within 5&quot; of this warjack gain +2 DEF. Interdiction Protocol expires at the end of the Pulse round.</description>
+              <description>Overdrive:
+
+Target a friendly warjack.
+
+Friendly warrior models within 5&quot; of this warjack gain +2 DEF.
+
+Interdiction Protocol expires at the end of the Pulse round.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -576,7 +1129,13 @@
           </constraints>
           <rules>
             <rule id="7ea2-5e9c-9675-53cc" name="-Cypher- Momentum Calibrator" hidden="false">
-              <description>Overdrive: Target a friendly warjack. When the warjack hits a model with an equal or smaller base with a melee attack, before damage is rolled, the model hit is slammed directly away from the warjack. Roll a number of action dice equal to the STR of the warjack. For every strike rolled, move the model hit 1&quot;. Collateral damage is equal to the STR of the attacking warjack. This card expires at the end of this turn.</description>
+              <description>Overdrive:
+
+Target a friendly warjack.
+
+When the warjack hits a model with an equal or smaller base with a melee attack, before damage is rolled, the model hit is slammed directly away from the warjack. Roll a number of action dice equal to the STR of the warjack. For every strike rolled, move the model hit 1&quot;. Collateral damage is equal to the STR of the attacking warjack.
+
+This card expires at the end of this turn.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -592,7 +1151,11 @@
           </constraints>
           <rules>
             <rule id="fb67-0a2a-9fa3-27ce" name="-Cypher- Kinetic Accelerator" hidden="false">
-              <description>Overdrive: Target a friendly warjack. When this warjack makes a melee attack during its activation, make a melee attack roll against each enemy model within the weapon&apos;s RNG. Models hit suffer the full effects and damage of the attack they were hit with. Kinetic Accelerator expires at the end of this turn.</description>
+              <description>Overdrive:
+
+Target a friendly warjack. When this warjack makes a melee attack during it&apos;s activation, make a melee attack roll aginst each enemy model within the weapon&apos;s RNG. Models hit suffer the full effects and damage of the attack they were hit with.
+
+Kinetic Accelerator expires at the end of this turn.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -608,7 +1171,11 @@
           </constraints>
           <rules>
             <rule id="fbeb-dcfd-fe2b-be78" name="-Cypher- Annihilation Vector" hidden="false">
-              <description>Overdrive: Target frinedly warjack. The warjack can immediately make one melee attack against an enemy model within 1&quot;. If the attack hits, the model hit suffers a damage roll with a POW equal to the attacking warjack&apos;s STR. This attack causes kinetic damage. Additionally, if the model hit was a warjack, it suffers the System Failure continuous effect.</description>
+              <description>Overdrive:
+
+Target friendly warjack.
+
+The warjack can immediately make one melee attack against an enemy model within 1&quot;. If the attack hits, the model hit suffers a damage roll with a POW equal to the attacking warjack&apos;s STR. This attack causes kinetic damage. Additionally, if the model hit was a warjack, it suffers the System Failure continuous effect.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -624,7 +1191,11 @@
           </constraints>
           <rules>
             <rule id="6f61-fa70-2f90-ccc6" name="-Cypher- Impulse Inducer" hidden="false">
-              <description>Overdrive: Target a frineldy warjack. Remove the activation token from the warjack.</description>
+              <description>Overdrive:
+
+Target a friendly warjack.
+
+Remove the activation token from the warjack.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -640,7 +1211,13 @@
           </constraints>
           <rules>
             <rule id="7fd3-f82a-bc88-cbeb" name="-Cypher- Ascension Catalyst" hidden="false">
-              <description>Overdrive: Target a frinedly warjack. The warjack gains +2 SPD and the Flight special rule. Ascension Catalyst expires at the end of this turn.</description>
+              <description>Overdrive:
+
+Target a friendly warjack.
+
+The warjack gains +2 SPD and the Flight special rule.
+
+Ascension Catalyst expires at the end of this turn.</description>
             </rule>
           </rules>
           <categoryLinks>
@@ -657,9 +1234,6 @@
     <rule id="7adb-f157-4c5d-c8a9" name="Mimetic Cloak (Charge)" hidden="false">
       <description>While this model is charged, it gains Stealth. A model with Stealth cannot be targeted by attacks made by models more than 8&quot; away.</description>
     </rule>
-    <rule id="094d-bc41-04ce-a04e" name="Phase Sequencer (Spike)" hidden="false">
-      <description>Once per activation, this unit can spike to use Phase Sequencer. That activation, models in this squad can move through obstructions and through other models if they have enough movement to move completely past them.</description>
-    </rule>
     <rule id="ee53-15d2-f2a6-4545" name="Force Projector (Charge)" hidden="false">
       <description>Fore each Arc this model is charged with, this model&apos;s melee weapons gain +1 RNG.</description>
     </rule>
@@ -673,7 +1247,7 @@
       <description>During its activation, this squad can spike to ignore cover and Stealth for the rest of its activation.</description>
     </rule>
     <rule id="2cb7-ba4d-ce4d-4e27" name="Reflex Accelerator (Charge)" hidden="false">
-      <description>When this model makes its attacks during its activation while it is charged, it can attack with all its weapons.</description>
+      <description>When this model makes its attacks during its activation while it is charged, it can attack with both its weapons.</description>
     </rule>
     <rule id="3ed5-a2a6-44a7-9c1d" name="Arc Relay (12)" hidden="false">
       <description>This model can channel Fury Cyphers. A Fury Cypher channeled through this model is RNG 12.</description>
@@ -688,7 +1262,7 @@
       <description>While this model is charged, Fury Cyphers channeled through it gain +5 RNG.</description>
     </rule>
     <rule id="c9e6-a3b3-fe05-7295" name="Realignment Codex (Spike)" hidden="false">
-      <description>Once per activation, this unit can spike to use Realignment Codex. When it does so, you can clear any amount of Arc from one friendly unit within 10&quot; of this model or charge one unit with any amount of Arc up to its limit.</description>
+      <description>Once per activation, this unit can spike to use Realignment Codex. When it does so, youcan clear any amount of Arc from one friendly unit within 10&quot; of this model or charge one unit with any amount of Arc up to its limit.</description>
     </rule>
     <rule id="f617-cd36-a4f8-cd90" name="Command Interface (Paladin) (Spike)" hidden="false">
       <description>During its activation, this model can spike to remove an activation token from a friendly Paladin squad within 10&quot; of it.</description>
@@ -699,23 +1273,14 @@
     <rule id="6fe1-a603-4323-af51" name="Slip Displacer (Spike)" hidden="false">
       <description>Once per activation, this model can spike to move 3&quot;.</description>
     </rule>
-    <rule id="6be3-b8b0-01b9-900c" name="Impulse Reactor (Charge)" hidden="false">
-      <description>While charged, if this unit has an activation token on it at the start of your turn, you can remove the activation token from this model.</description>
-    </rule>
     <rule id="ed37-1d75-e270-e479" name="Weapon Expert" hidden="false">
       <description>When this model attacks during its activation, it can attack with all of its weapons.</description>
     </rule>
     <rule id="e013-6944-6609-e65c" name="Arcantrik Turbine (Charge)" hidden="false">
       <description>This model gains +1 SPD for each Arc it is currently charged with.</description>
     </rule>
-    <rule id="403b-2f51-d670-cb59" name="Fury Reciprocator (Spike)" hidden="false">
-      <description>When you channel a Fury Cypher through this model, after the attack is resolved, this model can spike to return the Cypher card to your hand.</description>
-    </rule>
     <rule id="7e28-2524-d7db-abda" name="Fire &amp; Displace" hidden="false">
       <description>Immediately after resolving a ranged attack made by this model, this model can move up to 3&quot;.</description>
-    </rule>
-    <rule id="8d87-7a73-e467-d6cd" name="Repulsor Ram (Spike)" hidden="false">
-      <description>When this model is hit by a melee attack, after the attack is resolved, this model can spike once to use Repulsor Ram. The attacking model is immediately slammed 3&quot; directly away from this model. Collateral damage is equal to the POW of the attacking model&apos;s melee weapon.</description>
     </rule>
     <rule id="2060-8a7e-1170-aae4" name="Pathfinder" hidden="false">
       <description>This model ignores movement penalties for rough terrain.</description>
@@ -726,7 +1291,7 @@
     <rule id="f45d-f7bc-3379-d648" name="Power Attack (Spike)" hidden="false">
       <description>Immediately after hitting a warjack with this weapon, this model can spike to cause the warjack to suffer the system failure continuous effect.</description>
     </rule>
-    <rule id="cb00-7571-a4fd-84d6" name="Hunter-Killer Rounds (Spike)" hidden="false">
+    <rule id="cb00-7571-a4fd-84d6" name="Hunter-Killer Salvo (Spike)" hidden="false">
       <description>When making an attack with this weapon, this model can spike to ignore line of sight and cover when declaring the target and resolving the attack.</description>
     </rule>
     <rule id="77e6-c811-aef4-ee7f" name="Strafe" hidden="false">
@@ -735,8 +1300,8 @@
     <rule id="f174-cd6d-3802-1cbc" name="Null Strike" hidden="false">
       <description>Clear 1 Arc from the unit or void gate hit by this weapon.</description>
     </rule>
-    <rule id="4478-b4bd-42be-09e2" name="Blast Weapon" hidden="false">
-      <description>This is a Blast Weapon.</description>
+    <rule id="4478-b4bd-42be-09e2" name="Blast" hidden="false">
+      <description>This weapon causes Blast damage.</description>
     </rule>
     <rule id="74d3-0293-89c9-ba64" name="Stun Module (Spike)" hidden="false">
       <description>Immediately after hitting a target with this weapon, this model can spike to give the unit hit an activation token.</description>
@@ -750,35 +1315,17 @@
     <rule id="5555-7c59-a346-7406" name="Corrosion" hidden="false">
       <description>A model hit by this weapon suffers the corrosion continuous effect.</description>
     </rule>
-    <rule id="c56a-eb04-a80f-be7d" name="Spray Weapon" hidden="false">
+    <rule id="c56a-eb04-a80f-be7d" name="Spray" hidden="false">
       <description>This is a Spray Weapon.</description>
-    </rule>
-    <rule id="5c5b-ce9c-65e9-1bb6" name="Mechanikal Optics (Charge)" hidden="false">
-      <description>While this model is charged, this weapon gains +4 RNG.</description>
     </rule>
     <rule id="c2c4-1eac-f24e-09f5" name="Fire" hidden="false">
       <description>This weapon causes fire damage. A model hit by this weapon suffers the fire continuous effect.</description>
-    </rule>
-    <rule id="4b13-2e42-d9c4-4f2f" name="Arc Booster (Spike)" hidden="false">
-      <description>When attacking with this weapon, before making a damage roll, this model can spike to cause the target of the attack to suffer -1 ARM until the attack is resolved.</description>
-    </rule>
-    <rule id="24ab-84f6-b1d5-3fba" name="Nullifier" hidden="false">
-      <description>This attack causes no damage. Instead clear 1 ARC from the unit or void gate hit by the weapon.</description>
-    </rule>
-    <rule id="18a0-5c55-a14a-519d" name="Neural Net" hidden="false">
-      <description>This model gains a cumulative +1 DEF bonus for each other friendly unit within 5&quot; , up to a bonus of +3.</description>
     </rule>
     <rule id="6e59-f079-4476-730f" name="Smart Lock (Charge)" hidden="false">
       <description>While charged, this model ignores cover when making a ranged attack.</description>
     </rule>
     <rule id="fd08-4038-ea78-bdd4" name="Relentless" hidden="false">
       <description>When this model destroys one or more enemy models with a melee attack, immediately after the attack is resolved, this model can move up to 2&quot;.</description>
-    </rule>
-    <rule id="43d0-e95c-e7b5-3bb3" name="&apos;Jack Hunter (Spike)" hidden="false">
-      <description>Once per activation, this model can spike to use &apos;Jack Hunter. That activation, this model gains +3 action dice on its attack rolls targeting enemy warjacks.</description>
-    </rule>
-    <rule id="4eaf-902d-3737-14fe" name="Heightened Reflexes" hidden="false">
-      <description>When this model is targeted by an attack, after the attack is resolved, it can move up to 3&quot;.</description>
     </rule>
     <rule id="45b4-f347-8366-5808" name="Impulse Reciprocator (Spike)" hidden="false">
       <description>When this model is targeted and hit by an enemy attack, it can spike to use Impulse Reciprocator. If this model uses Impulse Reciprocator, immediately after the attack is resolved, this model can make one attack.</description>
@@ -802,10 +1349,10 @@
       <description>While charged, the models in this squad gain cover.</description>
     </rule>
     <rule id="c2f8-48d9-d6ed-1bdf" name="Force Ram (Spike)" hidden="false">
-      <description>When this model hits a target with an attack with this weapon, it can spike once to cause the target to be slammed rather than suffering the effects of Lock Down. Before damage is rolled, the model hit is slammed 3&quot; directly away from this model. Collateral damage is equal to the POW of this weapon.</description>
+      <description>When this model hits a target with an attack with this weapon, it can spike to cause the target to be slammed rather than suffering the effects of Paralysis. Before damage is rolled, the model hit is slammed 3&quot; directly away from this model. Collateral damage is equal to the POW of this weapon.</description>
     </rule>
     <rule id="c5f2-b7a9-63fd-e500" name="Lock Down" hidden="false">
-      <description>A model hit by this weapon suffers the Lock Down continuous effect.</description>
+      <description>A model hit by this weapon suffers the lock down continuous effect.</description>
     </rule>
     <rule id="214b-e301-de8e-4e3d" name="Afterburner (Spike)" hidden="false">
       <description>This model can spike at thestart of its activation to use Afterburner. During that activation, this model can advance a number of inches equal to its SPD x3 but cannot make any attacks.</description>
@@ -816,38 +1363,17 @@
     <rule id="62eb-2d21-2a6c-8b68" name="Flight" hidden="false">
       <description>This model gains Flight.</description>
     </rule>
-    <rule id="af72-afc1-816d-8398" name="Battle Cruiser" hidden="false">
-      <description>When this model makes a ranged attack, immediately after the attack is resolved, this model can move up to 1&quot;.</description>
-    </rule>
     <rule id="ebb5-c4d8-2797-e523" name="Dislocator (Spike)" hidden="false">
       <description>When this model hits an enemy model with this weapon, after the attack is resolved, this model can spike to reposition the model hit anywhere within 3&quot; of its current location.</description>
     </rule>
     <rule id="b3c5-5b94-5cca-52ed" name="High Intensity (Charge)" hidden="false">
       <description>When this model makes an attack with this weapon while charged, add two power dice to the attack roll for each Arc on it instead of one.</description>
     </rule>
-    <rule id="44eb-53c1-d618-01b8" name="Adrenalizer (Charge)" hidden="false">
-      <description>When this model is charged, other warrior models within 5&quot; of it gain +1 ARM and do not suffer continuous effects. Additionally, continuous effects on affected model immediately expire.</description>
-    </rule>
     <rule id="4339-3e50-7d6c-5e50" name="Repair (Action)" hidden="false">
       <description>This model can make a repair special action to repair a friendly model within 1&quot; of it. Roll three action dice. For each strike rolled, remove 1 damage point from the model being repaired.</description>
     </rule>
-    <rule id="343c-4bc9-0f7d-c741" name="Resurrection Protocol (Spike)" hidden="false">
-      <description>During its activation and while within 10&quot; of a target friendly squad, this model can spike to return up to two destroyed non-attachment models to the squad. Place these models within 2&quot; of another model in the squad. A squad can never have more than three trooper models as a result of Resurrection Protocol.</description>
-    </rule>
-    <rule id="3189-813b-6b69-49ec" name="Jump Jets (Spike)" hidden="false">
-      <description>Once per activation, this model can spike to gain +3 SPC and Flight until the end of its activation.</description>
-    </rule>
-    <rule id="1dbf-ada7-71d2-6c11" name="Thrusters (Charge)" hidden="false">
-      <description>While charged, this model ignores movement penalties for rough terrain. Additionally, for each Arc this model is charged with, it gains +1 DEF.</description>
-    </rule>
     <rule id="067d-b201-437d-8185" name="Advanced Optics" hidden="false">
       <description>This model&apos;s ranged weapons gain +2 RNG.</description>
-    </rule>
-    <rule id="8d84-efa6-1ae3-a78b" name="Bomber" hidden="false">
-      <description>This model gains +1 action die on attack rolls with explosion weapons. Additionally, when this model makes an attack with an explosion weapon while it has Flight, immediately after the attack is resolved, this model can move up to 2&quot;.</description>
-    </rule>
-    <rule id="af3d-83e5-57d5-14c6" name="Explosive Collapse" hidden="false">
-      <description>If this weapon targets and destroys an enemy model, other models within 2&quot; of the model targeted suffer a POW 4 damage roll.</description>
     </rule>
     <rule id="058b-f612-39f3-2bd6" name="Jump Start (Spike)" hidden="false">
       <description>During its activation, this model can spike to remove an activation token from a friendly warjack within 10&quot; of it.</description>
@@ -879,12 +1405,6 @@
     <rule id="4769-9fbb-0de5-9570" name="Psycho Relay" hidden="false">
       <description>While this unit is in play, you can have up to six Cypher cards in your hand at any time.</description>
     </rule>
-    <rule id="c3f2-8bf3-13f4-a729" name="Thanotech Reclaimer (Spike)" hidden="false">
-      <description>This model can spike to use Thanotech at any time during its activation. When it does so you can return any Cypher card in your discard pile to your hand.</description>
-    </rule>
-    <rule id="4c2b-8ff6-dbbb-8525" name="Maelstrom Activator (Spike)" hidden="false">
-      <description>During this unit&apos;s activation, immediately after completing its attacks this model can spike to make one additional attack with each of its weapons.</description>
-    </rule>
     <rule id="468a-cdd0-c1f0-4d47" name="Attack Mode (Arclock Pistol)" hidden="false">
       <description>Each time this weapon is used to make an attack, choose one of the following special rules:
 - Blast Weapon - This is a Blast Weapon.
@@ -915,9 +1435,6 @@
     <rule id="07c2-cd31-0208-e66a" name="Gate Jammer (Charge)" hidden="false">
       <description>While this model is charged, increase the Deployment Cost of enemy units deployed from Void Gates within 10&quot; of this model by 1.</description>
     </rule>
-    <rule id="a862-92a3-7800-6e64" name="Neural Web" hidden="false">
-      <description>This model gains a cumulative +1 MAT bonus for each other friendly unit with 5&quot;, up to a bonus of +3</description>
-    </rule>
     <rule id="834a-f198-e6c0-5923" name="Defense Matrix (Charge)" hidden="false">
       <description>While this model is charged, it gains +3 DEF against ballistic weapons.</description>
     </rule>
@@ -933,76 +1450,59 @@
     <rule id="92ca-26e8-fd63-05ce" name="Winch" hidden="false">
       <description>When this weapon damages an enemy model with an equal or smaller base, immediately after the attack is resolved, the damage model can be moved directly toward this model unit it contacts a model, an obstacle, or structure.</description>
     </rule>
-    <rule id="5e13-0046-6809-c381" name="Rapid Strike" hidden="false">
-      <description>When this model attacks during its activation, it can make one additional melee atack with each of its melee weapons.</description>
-    </rule>
-    <rule id="4a62-dd5f-b896-d12c" name="Armor-Piercing" hidden="false">
+    <rule id="4a62-dd5f-b896-d12c" name="Armor Piercing" hidden="false">
       <description>When resolving a damage roll for an attack made with this weapon, reduce the target&apos;s ARM by 1.</description>
     </rule>
-    <rule id="fbcf-7d2a-48f0-4286" name="Eruption" hidden="false">
-      <description>When this model chooses to use Eruption it makes its attacks during its activation. If it does so, all other models within 3&quot; of it each suffer a POW 3 explosion damage roll.</description>
+    <rule id="87fe-98b8-3637-f640" name="Power Focus (Spike)" hidden="false">
+      <description>Before this model attacks during it&apos;s activation, it can spike to use Power Foxus. This model can only attack with one of it&apos;s weapons that activation, but adds three POWER dice to attack rolls that activation. Additionally, this model can reroll it&apos;s attack rolls with the chosen weapon that activation. A roll can be rerolled once as a result of Power Focus.</description>
     </rule>
-    <rule id="8e98-cf4d-0227-ff7b" name="Hunter-Killer Salvo (Spike)" hidden="false">
-      <description>During its activation, this squad can spike to ignore line of sight and cover when making ranged attacks for the rest of its activation.</description>
+    <rule id="f894-5e6e-fa49-2330" name="Dominion Converter" hidden="false">
+      <description>When this model is hit by an enemy attack, immediately after the attack is resolved, you can charge this model.</description>
     </rule>
-    <rule id="9b60-e71e-a84d-0bd7" name="Cleave" hidden="false">
-      <description>If this model destroys an enemy model with an attack with this weapon, it can immediately make an additional attack with this weapon. Attacks generated by Cleave cannot generate furher additional attacks.</description>
+    <rule id="9e4e-f8cd-00eb-cad9" name="Kinetic" hidden="false"/>
+    <rule id="6c5c-9284-ad97-ece8" name="Melee" hidden="false"/>
+    <rule id="4c03-2674-46a3-4674" name="Ballistic" hidden="false"/>
+    <rule id="15d3-b3f8-98ef-48bc" name="Ranged" hidden="false"/>
+    <rule id="8373-ff2e-7769-c5a7" name="Force" hidden="false"/>
+    <rule id="f7b6-783e-1ae9-465d" name="Explosion" hidden="false"/>
+    <rule id="416c-f81b-c698-5f02" name="Beam" hidden="false">
+      <description>This weapon causes Beam damage.</description>
+    </rule>
+    <rule id="9b9d-84ff-3a95-2643" name="Evasive Action" hidden="false">
+      <description>This vehicle can reroll Defense rolls. A roll can be rerolled once as a result of Evasive Action. This maneuver expires at the start of the unit&apos;s next activation.</description>
+    </rule>
+    <rule id="adcf-4047-c0a2-154b" name="Aegis Field (Charge)" hidden="false">
+      <description>While charged, this model gains Cover.</description>
+    </rule>
+    <rule id="f884-bbdf-1755-7f40" name="Energy" hidden="false">
+      <description>This weapon causes Energy damage.</description>
+    </rule>
+    <rule id="7d92-ecde-abcd-cac0" name="Deployable Cover" hidden="false">
+      <description>This model provides cover as though it were terrain but may never gain cover itself.</description>
+    </rule>
+    <rule id="454e-3b8b-3de2-856d" name="Field Reinforcement" publicationId="216d-9058-fe0b-7be3" hidden="false">
+      <description>Remove 1 damage point from this model at the start of each of your turns.</description>
+    </rule>
+    <rule id="4e47-8e74-5d7d-c90f" name="Arc Relay (14)" hidden="false">
+      <description>This model can channel Fury Cyphers. A Fury Cypher channeled through this model is RNG 14.</description>
+    </rule>
+    <rule id="77c5-00b4-a116-e328" name="Slip Field (Charge)" hidden="false">
+      <description>When this model is targeted by an attack while charged, after that attack is resolved, this model can move up to 3&quot;.</description>
+    </rule>
+    <rule id="4a41-827f-6868-3087" name="Blast Shielding" hidden="false">
+      <description>While within 2&quot; of this model, friendly models gain the Compound Armor advantage.</description>
+    </rule>
+    <rule id="4bcb-c9b9-251a-f2a5" name="Singularity Collapse" hidden="false">
+      <description>If this weapon targets and destroys an enemy model, other models within 2&quot; of the model targeted suffer a POW 4 damage roll.</description>
+    </rule>
+    <rule id="e94a-94b2-5aeb-5014" name="Gate Launcher (Spike)" hidden="false">
+      <description>Once per activation, this model can spike to place a void gate within 5&quot; of it&apos;s current location.</description>
+    </rule>
+    <rule id="6c6d-1869-f1f7-4c03" name="Cold" hidden="false">
+      <description>This weapon causes Cold damage.</description>
+    </rule>
+    <rule id="592d-4c1c-98fb-122f" name="Dynamic Accelerator (Charge)" hidden="false">
+      <description>While charged, this model ignores movement terrain penalties for rough terrain.</description>
     </rule>
   </sharedRules>
-  <sharedProfiles>
-    <profile id="5823-c72a-bd39-bc1b" name="Magnun" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Ballistic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">8</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="7a8e-8657-abf4-9a78" name="Oblivion" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">5</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">High Intensity (Charge), Gorge, Siphon Power</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f41f-4dac-afb3-2b9b" name="Fusion Sword" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">4</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-    <profile id="fb56-1a6a-27da-80fc" name="Force Constrictor" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Force</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">10</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Stun Module (Spike)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1b2e-337d-d5c1-7b91" name="Null Detonator" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Energy</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Ranged</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">6</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">-</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830">Nullifier</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a3bf-d8a7-97e1-c766" name="Combat Blade" hidden="false" typeId="3601-946f-42f1-0f5c" typeName="Weapon">
-      <characteristics>
-        <characteristic name="DMG" typeId="bd77-31aa-5209-2b6c">Kinetic</characteristic>
-        <characteristic name="TYP" typeId="684a-ebe0-b4ae-1d02">Melee</characteristic>
-        <characteristic name="RNG" typeId="a6dd-0c75-98a7-e08a">1</characteristic>
-        <characteristic name="POW" typeId="9750-e740-35f4-1cf6">3</characteristic>
-        <characteristic name="Rules" typeId="b9f6-e564-4386-9830"/>
-      </characteristics>
-    </profile>
-  </sharedProfiles>
 </gameSystem>


### PR DESCRIPTION
- Adds the new models from Collision Course
- Refactors shared entries to only be global if more than one faction uses them
- Refactors weapons as 'Entries' (example taken from KT21 by Mad-Spy)